### PR TITLE
ECL-188: API to validate registration data before submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The service provides APIs to be consumed by [economic-crime-levy-registration-fr
 - Get registration: `GET /economic-crime-levy-registration/registrations/:id`  
 - Delete registration: `DELETE /economic-crime-levy-registration/registrations/:id`
 - [Get subscription status](api-docs/get-subscription-status.md): `GET /economic-crime-levy-registration/subscription-status/:businessPartnerId`
+- [Validate registration](api-docs/validate-registration.md): `GET /economic-crime-levy-registration/registrations/validate/:id`
 
 ## Running the service
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The service provides APIs to be consumed by [economic-crime-levy-registration-fr
 - Get registration: `GET /economic-crime-levy-registration/registrations/:id`  
 - Delete registration: `DELETE /economic-crime-levy-registration/registrations/:id`
 - [Get subscription status](api-docs/get-subscription-status.md): `GET /economic-crime-levy-registration/subscription-status/:businessPartnerId`
-- [Validate registration](api-docs/validate-registration.md): `GET /economic-crime-levy-registration/registrations/validate/:id`
+- [Get registration validation errors](api-docs/get-registration-validation-errors.md): `GET /economic-crime-levy-registration/registrations/:id/validation-errors`
 
 ## Running the service
 

--- a/api-docs/get-registration-validation-errors.md
+++ b/api-docs/get-registration-validation-errors.md
@@ -1,10 +1,10 @@
-# Validate Registration
+# Get Registration Validation Errors
 
-Validate a registration that is held in mongo to ensure that is has no errors and can be submitted to the HoD.
+Validates a registration that is held in mongo and returns any errors that mean the subscription cannot be submitted to the HoD.
 
-**URL**: `/economic-crime-levy-registration/registrations/validate/:id`
+**URL**: `/economic-crime-levy-registration/registrations/:id/validation-errors`
 
-**Method**: `POST`
+**Method**: `GET`
 
 **Required URI Parameters**:
 
@@ -20,11 +20,11 @@ Validate a registration that is held in mongo to ensure that is has no errors an
 
 ## Responses
 
-### The registration is valid and can be submitted to the HoD
+### The registration is valid and no errors are returned
 
 **Code**: `204 NO_CONTENT`
 
-### The registration is not valid and therefore should not be submitted to the HoD
+### The registration is not valid and validations errors are returned
 
 **Code**: `200 OK`
 

--- a/api-docs/get-registration-validation-errors.md
+++ b/api-docs/get-registration-validation-errors.md
@@ -1,6 +1,7 @@
 # Get Registration Validation Errors
 
-Validates a registration that is held in mongo and returns any errors that mean the subscription cannot be submitted to the HoD.
+Validates a registration that is held in mongo and returns any errors that mean the subscription cannot be submitted to
+the HoD.
 
 **URL**: `/economic-crime-levy-registration/registrations/:id/validation-errors`
 
@@ -30,13 +31,15 @@ Validates a registration that is held in mongo and returns any errors that mean 
 
 **Response Body Example**
 
-Data validation error descriptions are returned in the body:
-
 ```json
 {
   "errors": [
-    "Data item 1 is missing",
-    "Data item 2 is missing"
+    {
+      "message": "Data item 1 is missing"
+    },
+    {
+      "message": "Data item 2 is missing"
+    }
   ]
 }
 ```

--- a/api-docs/get-subscription-status.md
+++ b/api-docs/get-subscription-status.md
@@ -18,7 +18,9 @@ Get the ECL subscription status for a given business partner ID.
 |---------------|--------------|--------------|
 | Authorization | Bearer {TOKEN} | A valid bearer token from the auth service |
 
-## Success Response
+## Responses
+
+### Subscription status is returned
 
 **Code**: `200 OK`
 

--- a/api-docs/validate-registration.md
+++ b/api-docs/validate-registration.md
@@ -1,0 +1,47 @@
+# Validate Registration
+
+Validate a registration that is held in mongo to ensure that is has no errors and can be submitted to the HoD.
+
+**URL**: `/economic-crime-levy-registration/registrations/validate/:id`
+
+**Method**: `POST`
+
+**Required URI Parameters**:
+
+| Parameter | Description                               |
+|-----------|-------------------------------------------|
+| id        | The ID of the registration held in mongo. |
+
+**Required Request Headers**:
+
+| Header Name   | Header Value   | Description                                |
+|---------------|----------------|--------------------------------------------|
+| Authorization | Bearer {TOKEN} | A valid bearer token from the auth service |
+
+## Responses
+
+### The registration is valid and can be submitted to the HoD
+
+**Code**: `204 NO_CONTENT`
+
+### The registration is not valid and therefore should not be submitted to the HoD
+
+**Code**: `200 OK`
+
+**Response Body Example**
+
+Data validation error descriptions are returned in the body:
+
+```json
+{
+  "errors": [
+    "Data item 1 is missing",
+    "Data item 2 is missing"
+  ]
+}
+```
+
+### A registration could not be found in mongo for the given ID
+
+**Code**: `404 NOT_FOUND`
+

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationController.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.controllers
+
+import cats.data.Validated.{Invalid, Valid}
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.AuthorisedAction
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationErrors
+import uk.gov.hmrc.economiccrimelevyregistration.repositories.RegistrationRepository
+import uk.gov.hmrc.economiccrimelevyregistration.services.RegistrationValidationService
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton()
+class RegistrationValidationController @Inject() (
+  cc: ControllerComponents,
+  registrationRepository: RegistrationRepository,
+  authorise: AuthorisedAction,
+  registrationValidationService: RegistrationValidationService
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc) {
+
+  def validateRegistration(id: String): Action[AnyContent] = authorise.async { _ =>
+    registrationRepository.get(id).map {
+      case Some(registration) =>
+        registrationValidationService.validateRegistration(registration) match {
+          case Valid(_)   => NoContent
+          case Invalid(e) => Ok(Json.toJson(DataValidationErrors(e.toNonEmptyList.toList.map(_.message))))
+        }
+      case None               => NotFound
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationController.scala
@@ -37,7 +37,7 @@ class RegistrationValidationController @Inject() (
 )(implicit ec: ExecutionContext)
     extends BackendController(cc) {
 
-  def validateRegistration(id: String): Action[AnyContent] = authorise.async { _ =>
+  def getValidationErrors(id: String): Action[AnyContent] = authorise.async { _ =>
     registrationRepository.get(id).map {
       case Some(registration) =>
         registrationValidationService.validateRegistration(registration) match {

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationController.scala
@@ -42,7 +42,7 @@ class RegistrationValidationController @Inject() (
       case Some(registration) =>
         registrationValidationService.validateRegistration(registration) match {
           case Valid(_)   => NoContent
-          case Invalid(e) => Ok(Json.toJson(DataValidationErrors(e.toNonEmptyList.toList.map(_.message))))
+          case Invalid(e) => Ok(Json.toJson(DataValidationErrors(e.toNonEmptyList.toList)))
         }
       case None               => NotFound
     }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/Registration.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/Registration.scala
@@ -41,4 +41,21 @@ final case class Registration(
 
 object Registration {
   implicit val format: OFormat[Registration] = Json.format[Registration]
+
+  def empty(internalId: String): Registration = Registration(
+    internalId = internalId,
+    entityType = None,
+    meetsRevenueThreshold = None,
+    amlSupervisor = None,
+    incorporatedEntityJourneyData = None,
+    soleTraderEntityJourneyData = None,
+    partnershipEntityJourneyData = None,
+    startedAmlRegulatedActivityInCurrentFy = None,
+    amlRegulatedActivityStartDate = None,
+    businessSector = None,
+    contacts = Contacts.empty,
+    useRegisteredOfficeAddressAsContactAddress = None,
+    contactAddress = None,
+    contactAddressIsUk = None
+  )
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/errors/DataValidationError.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/errors/DataValidationError.scala
@@ -24,7 +24,7 @@ object DataValidationError {
   implicit val format: OFormat[DataValidationError] = Json.format[DataValidationError]
 }
 
-final case class DataValidationErrors(errors: Seq[String])
+final case class DataValidationErrors(errors: Seq[DataValidationError])
 
 object DataValidationErrors {
   implicit val format: OFormat[DataValidationErrors] = Json.format[DataValidationErrors]

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/errors/DataValidationError.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/errors/DataValidationError.scala
@@ -14,29 +14,18 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.economiccrimelevyregistration.models
+package uk.gov.hmrc.economiccrimelevyregistration.models.errors
 
 import play.api.libs.json.{Json, OFormat}
 
-final case class Contacts(
-  firstContactDetails: ContactDetails,
-  secondContact: Option[Boolean],
-  secondContactDetails: ContactDetails
-)
+final case class DataValidationError(message: String)
 
-object Contacts {
-  implicit val format: OFormat[Contacts] = Json.format[Contacts]
-
-  def empty: Contacts = Contacts(ContactDetails(None, None, None, None), None, ContactDetails(None, None, None, None))
+object DataValidationError {
+  implicit val format: OFormat[DataValidationError] = Json.format[DataValidationError]
 }
 
-final case class ContactDetails(
-  name: Option[String],
-  role: Option[String],
-  emailAddress: Option[String],
-  telephoneNumber: Option[String]
-)
+final case class DataValidationErrors(errors: Seq[String])
 
-object ContactDetails {
-  implicit val format: OFormat[ContactDetails] = Json.format[ContactDetails]
+object DataValidationErrors {
+  implicit val format: OFormat[DataValidationErrors] = Json.format[DataValidationErrors]
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.services
+
+import cats.data.ValidatedNec
+import cats.implicits._
+import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType._
+import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationError
+import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{IncorporatedEntityJourneyData, PartnershipEntityJourneyData, SoleTraderEntityJourneyData}
+
+import javax.inject.Inject
+
+class RegistrationValidationService @Inject() () {
+
+  type ValidationResult[A] = ValidatedNec[DataValidationError, A]
+
+  def validateRegistration(registration: Registration): ValidationResult[Registration] =
+    (
+      validateGrsJourneyData(registration),
+      validateOptExists(registration.contacts.firstContactDetails.name, missingErrorMessage("First contact name")),
+      validateOptExists(registration.contacts.firstContactDetails.role, missingErrorMessage("First contact role")),
+      validateOptExists(
+        registration.contacts.firstContactDetails.emailAddress,
+        missingErrorMessage("First contact email")
+      ),
+      validateOptExists(
+        registration.contacts.firstContactDetails.telephoneNumber,
+        missingErrorMessage("First contact number")
+      ),
+      validateOptExists(registration.businessSector, missingErrorMessage("Business sector")),
+      validateOptExists(registration.contactAddress, missingErrorMessage("Contact address")),
+      validateOptExists(registration.amlSupervisor, missingErrorMessage("AML supervisor")),
+      validateSecondContactDetails(registration)
+    ).mapN((_, _, _, _, _, _, _, _, _) => registration)
+
+  private def validateSecondContactDetails(registration: Registration): ValidationResult[Registration] =
+    registration.contacts.secondContact match {
+      case Some(true)  =>
+        (
+          validateOptExists(
+            registration.contacts.secondContactDetails.name,
+            missingErrorMessage("Second contact name")
+          ),
+          validateOptExists(
+            registration.contacts.secondContactDetails.role,
+            missingErrorMessage("Second contact role")
+          ),
+          validateOptExists(
+            registration.contacts.secondContactDetails.emailAddress,
+            missingErrorMessage("Second contact email")
+          ),
+          validateOptExists(
+            registration.contacts.secondContactDetails.telephoneNumber,
+            missingErrorMessage("Second contact number")
+          )
+        ).mapN((_, _, _, _) => registration)
+      case Some(false) => registration.validNec
+      case _           => DataValidationError(missingErrorMessage("Second contact choice")).invalidNec
+    }
+
+  private def validateGrsJourneyData(registration: Registration): ValidationResult[Registration] = {
+    val grsJourneyData: (
+      Option[IncorporatedEntityJourneyData],
+      Option[PartnershipEntityJourneyData],
+      Option[SoleTraderEntityJourneyData]
+    ) = (
+      registration.incorporatedEntityJourneyData,
+      registration.partnershipEntityJourneyData,
+      registration.soleTraderEntityJourneyData
+    )
+
+    val validateBusinessPartnerId: Option[String] => ValidationResult[Registration] = {
+      case Some(_) => registration.validNec
+      case _       => DataValidationError(missingErrorMessage("Business partner ID")).invalidNec
+    }
+
+    registration.entityType match {
+      case Some(UkLimitedCompany) =>
+        grsJourneyData match {
+          case (Some(i), None, None) => validateBusinessPartnerId(i.registration.registeredBusinessPartnerId)
+          case _                     => DataValidationError(missingErrorMessage("Incorporated entity data")).invalidNec
+        }
+      case Some(
+            LimitedLiabilityPartnership | GeneralPartnership | ScottishPartnership | LimitedPartnership |
+            ScottishLimitedPartnership
+          ) =>
+        grsJourneyData match {
+          case (None, Some(p), None) => validateBusinessPartnerId(p.registration.registeredBusinessPartnerId)
+          case _                     => DataValidationError(missingErrorMessage("Partnership data")).invalidNec
+        }
+      case Some(SoleTrader)       =>
+        grsJourneyData match {
+          case (None, None, Some(s)) => validateBusinessPartnerId(s.registration.registeredBusinessPartnerId)
+          case _                     => DataValidationError(missingErrorMessage("Sole trader data")).invalidNec
+        }
+      case _                      => DataValidationError(missingErrorMessage("Entity type")).invalidNec
+    }
+  }
+
+  private def missingErrorMessage(missingDataDescription: String): String = s"$missingDataDescription is missing"
+
+  private def validateOptExists[T](optData: Option[T], description: String): ValidationResult[T] =
+    optData match {
+      case Some(value) => value.validNec
+      case _           => DataValidationError(description).invalidNec
+    }
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -4,6 +4,6 @@ GET           /registrations/:id                             uk.gov.hmrc.economi
 PUT           /registrations                                 uk.gov.hmrc.economiccrimelevyregistration.controllers.RegistrationController.upsertRegistration
 DELETE        /registrations/:id                             uk.gov.hmrc.economiccrimelevyregistration.controllers.RegistrationController.deleteRegistration(id)
 
-POST          /registrations/validate/:id                    uk.gov.hmrc.economiccrimelevyregistration.controllers.RegistrationValidationController.validateRegistration(id)
+GET           /registrations/:id/validation-errors           uk.gov.hmrc.economiccrimelevyregistration.controllers.RegistrationValidationController.getValidationErrors(id)
 
 GET           /subscription-status/:businessPartnerId        uk.gov.hmrc.economiccrimelevyregistration.controllers.SubscriptionStatusController.getSubscriptionStatus(businessPartnerId)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -4,4 +4,6 @@ GET           /registrations/:id                             uk.gov.hmrc.economi
 PUT           /registrations                                 uk.gov.hmrc.economiccrimelevyregistration.controllers.RegistrationController.upsertRegistration
 DELETE        /registrations/:id                             uk.gov.hmrc.economiccrimelevyregistration.controllers.RegistrationController.deleteRegistration(id)
 
+POST          /registrations/validate/:id                    uk.gov.hmrc.economiccrimelevyregistration.controllers.RegistrationValidationController.validateRegistration(id)
+
 GET           /subscription-status/:businessPartnerId        uk.gov.hmrc.economiccrimelevyregistration.controllers.SubscriptionStatusController.getSubscriptionStatus(businessPartnerId)

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationISpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.play.bootstrap.backend.http.ErrorResponse
 
 class RegistrationISpec extends ISpecBase {
 
-  s"PUT /$contextPath/registrations"        should {
+  s"PUT ${routes.RegistrationController.upsertRegistration.url}"           should {
     "create or update a registration and return 200 OK with the registration" in {
       stubAuthorised()
 
@@ -46,7 +46,7 @@ class RegistrationISpec extends ISpecBase {
     }
   }
 
-  s"GET /$contextPath/registrations/:id"    should {
+  s"GET ${routes.RegistrationController.getRegistration(":id").url}"       should {
     "return 200 OK with a registration that is already in the database" in {
       stubAuthorised()
 
@@ -75,7 +75,7 @@ class RegistrationISpec extends ISpecBase {
     }
   }
 
-  s"DELETE /$contextPath/registrations/:id" should {
+  s"DELETE ${routes.RegistrationController.deleteRegistration(":id").url}" should {
     "delete a registration and return 204 NO_CONTENT" in {
       stubAuthorised()
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationValidationISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationValidationISpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationErr
 
 class RegistrationValidationISpec extends ISpecBase {
 
-  s"POST ${routes.RegistrationValidationController.validateRegistration(":id").url}" should {
+  s"GET ${routes.RegistrationValidationController.getValidationErrors(":id").url}" should {
     "return 204 NO_CONTENT when the registration data is valid" in {
       stubAuthorised()
 
@@ -41,7 +41,7 @@ class RegistrationValidationISpec extends ISpecBase {
       lazy val validationResult =
         callRoute(
           FakeRequest(
-            routes.RegistrationValidationController.validateRegistration(validRegistration.registration.internalId)
+            routes.RegistrationValidationController.getValidationErrors(validRegistration.registration.internalId)
           )
         )
 
@@ -60,7 +60,7 @@ class RegistrationValidationISpec extends ISpecBase {
       ).futureValue
 
       lazy val validationResult =
-        callRoute(FakeRequest(routes.RegistrationValidationController.validateRegistration(internalId)))
+        callRoute(FakeRequest(routes.RegistrationValidationController.getValidationErrors(internalId)))
 
       val expectedErrors = Seq(
         "AML supervisor is missing",
@@ -84,7 +84,7 @@ class RegistrationValidationISpec extends ISpecBase {
       val internalId = random[String]
 
       lazy val validationResult =
-        callRoute(FakeRequest(routes.RegistrationValidationController.validateRegistration(internalId)))
+        callRoute(FakeRequest(routes.RegistrationValidationController.getValidationErrors(internalId)))
 
       status(validationResult) shouldBe NOT_FOUND
     }

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationValidationISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationValidationISpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration
+
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
+import play.api.libs.json.Json
+import play.api.test.FakeRequest
+import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
+import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationErrors
+
+class RegistrationValidationISpec extends ISpecBase {
+
+  s"POST ${routes.RegistrationValidationController.validateRegistration(":id").url}" should {
+    "return 204 NO_CONTENT when the registration data is valid" in {
+      stubAuthorised()
+
+      val validRegistration = random[ValidRegistration]
+
+      callRoute(
+        FakeRequest(routes.RegistrationController.upsertRegistration).withJsonBody(
+          Json.toJson(validRegistration.registration)
+        )
+      ).futureValue
+
+      lazy val validationResult =
+        callRoute(
+          FakeRequest(
+            routes.RegistrationValidationController.validateRegistration(validRegistration.registration.internalId)
+          )
+        )
+
+      status(validationResult) shouldBe NO_CONTENT
+    }
+
+    "return 200 OK with validation errors in the JSON response body when the registration data is invalid" in {
+      stubAuthorised()
+
+      val internalId = random[String]
+
+      val invalidRegistration = Registration.empty(internalId)
+
+      callRoute(
+        FakeRequest(routes.RegistrationController.upsertRegistration).withJsonBody(Json.toJson(invalidRegistration))
+      ).futureValue
+
+      lazy val validationResult =
+        callRoute(FakeRequest(routes.RegistrationValidationController.validateRegistration(internalId)))
+
+      val expectedErrors = Seq(
+        "AML supervisor is missing",
+        "Business sector is missing",
+        "First contact name is missing",
+        "First contact role is missing",
+        "First contact email is missing",
+        "First contact number is missing",
+        "Contact address is missing",
+        "Entity type is missing",
+        "Second contact choice is missing"
+      )
+
+      status(validationResult)                                      shouldBe OK
+      contentAsJson(validationResult).as[DataValidationErrors].errors should contain allElementsOf expectedErrors
+    }
+
+    "return 404 NOT_FOUND when there is no registration data to validate" in {
+      stubAuthorised()
+
+      val internalId = random[String]
+
+      lazy val validationResult =
+        callRoute(FakeRequest(routes.RegistrationValidationController.validateRegistration(internalId)))
+
+      status(validationResult) shouldBe NOT_FOUND
+    }
+  }
+
+}

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationValidationISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationValidationISpec.scala
@@ -22,7 +22,7 @@ import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
 import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
-import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationErrors
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.{DataValidationError, DataValidationErrors}
 
 class RegistrationValidationISpec extends ISpecBase {
 
@@ -63,15 +63,15 @@ class RegistrationValidationISpec extends ISpecBase {
         callRoute(FakeRequest(routes.RegistrationValidationController.getValidationErrors(internalId)))
 
       val expectedErrors = Seq(
-        "AML supervisor is missing",
-        "Business sector is missing",
-        "First contact name is missing",
-        "First contact role is missing",
-        "First contact email is missing",
-        "First contact number is missing",
-        "Contact address is missing",
-        "Entity type is missing",
-        "Second contact choice is missing"
+        DataValidationError("AML supervisor is missing"),
+        DataValidationError("Business sector is missing"),
+        DataValidationError("First contact name is missing"),
+        DataValidationError("First contact role is missing"),
+        DataValidationError("First contact email is missing"),
+        DataValidationError("First contact number is missing"),
+        DataValidationError("Contact address is missing"),
+        DataValidationError("Entity type is missing"),
+        DataValidationError("Second contact choice is missing")
       )
 
       status(validationResult)                                      shouldBe OK

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/SubscriptionStatusISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/SubscriptionStatusISpec.scala
@@ -9,7 +9,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.EclSubscriptionStatus._
 
 class SubscriptionStatusISpec extends ISpecBase {
 
-  s"GET ${routes.SubscriptionStatusController.getSubscriptionStatus(":businessPartnerId")}" should {
+  s"GET ${routes.SubscriptionStatusController.getSubscriptionStatus(":businessPartnerId").url}" should {
     "return 200 OK with a subscribed ECL subscription status and the ECL registration reference" in {
       stubAuthorised()
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/SubscriptionStatusISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/SubscriptionStatusISpec.scala
@@ -9,7 +9,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.EclSubscriptionStatus._
 
 class SubscriptionStatusISpec extends ISpecBase {
 
-  s"GET /$contextPath/subscription-status/:businessPartnerId" should {
+  s"GET ${routes.SubscriptionStatusController.getSubscriptionStatus(":businessPartnerId")}" should {
     "return 200 OK with a subscribed ECL subscription status and the ECL registration reference" in {
       stubAuthorised()
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/base/ISpecBase.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/base/ISpecBase.scala
@@ -68,8 +68,6 @@ abstract class ISpecBase
     "integration-framework"
   )
 
-  val contextPath: String = "economic-crime-levy-registration"
-
   override def fakeApplication(): Application =
     GuiceApplicationBuilder()
       .disable[com.kenshoo.play.metrics.PlayModule]

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,8 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % "7.11.0",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % "0.73.0"
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % "0.73.0",
+    "org.typelevel"     %% "cats-core"                 % "2.9.0"
   )
 
   val test: Seq[ModuleID]    = Seq(

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
@@ -19,11 +19,17 @@ package uk.gov.hmrc.economiccrimelevyregistration
 import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
 import org.scalacheck.derive.MkArbitrary
 import org.scalacheck.{Arbitrary, Gen}
-import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
+import uk.gov.hmrc.economiccrimelevyregistration.models.AmlSupervisorType.Hmrc
+import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType.UkLimitedCompany
+import uk.gov.hmrc.economiccrimelevyregistration.models._
+import uk.gov.hmrc.economiccrimelevyregistration.models.grs.IncorporatedEntityJourneyData
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.EtmpSubscriptionStatus._
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.{Channel, EtmpSubscriptionStatus, SubscriptionStatusResponse}
 
 import java.time.{Instant, LocalDate}
+
+final case class ValidRegistration(registration: Registration)
 
 trait EclTestData {
 
@@ -54,6 +60,45 @@ trait EclTestData {
       idType,
       idValue,
       channel
+    )
+  }
+
+  implicit val arbValidRegistration: Arbitrary[ValidRegistration] = Arbitrary {
+    for {
+      registration                  <- MkArbitrary[Registration].arbitrary.arbitrary
+      internalId                    <- Arbitrary.arbitrary[String]
+      incorporatedEntityJourneyData <- Arbitrary.arbitrary[IncorporatedEntityJourneyData]
+      businessPartnerId             <- Arbitrary.arbitrary[String]
+      businessSector                <- Arbitrary.arbitrary[BusinessSector]
+      firstContactName              <- Arbitrary.arbitrary[String]
+      firstContactRole              <- Arbitrary.arbitrary[String]
+      firstContactEmail             <- Arbitrary.arbitrary[String]
+      firstContactNumber            <- Arbitrary.arbitrary[String]
+      eclAddress                    <- Arbitrary.arbitrary[EclAddress]
+    } yield ValidRegistration(
+      registration.copy(
+        internalId = internalId,
+        entityType = Some(UkLimitedCompany),
+        incorporatedEntityJourneyData = Some(
+          incorporatedEntityJourneyData.copy(registration =
+            incorporatedEntityJourneyData.registration.copy(registeredBusinessPartnerId = Some(businessPartnerId))
+          )
+        ),
+        partnershipEntityJourneyData = None,
+        soleTraderEntityJourneyData = None,
+        amlSupervisor = Some(AmlSupervisor(Hmrc, None)),
+        businessSector = Some(businessSector),
+        contacts = Contacts.empty.copy(
+          firstContactDetails = ContactDetails(
+            name = Some(firstContactName),
+            role = Some(firstContactRole),
+            emailAddress = Some(firstContactEmail),
+            telephoneNumber = Some(firstContactNumber)
+          ),
+          secondContact = Some(false)
+        ),
+        contactAddress = Some(eclAddress)
+      )
     )
   }
 

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
@@ -21,7 +21,7 @@ import org.scalacheck.derive.MkArbitrary
 import org.scalacheck.{Arbitrary, Gen}
 import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models.AmlSupervisorType.Hmrc
-import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType.UkLimitedCompany
+import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs.IncorporatedEntityJourneyData
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.EtmpSubscriptionStatus._
@@ -30,6 +30,8 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.{Ch
 import java.time.{Instant, LocalDate}
 
 final case class ValidRegistration(registration: Registration)
+
+final case class PartnershipType(entityType: EntityType)
 
 trait EclTestData {
 
@@ -100,6 +102,20 @@ trait EclTestData {
         contactAddress = Some(eclAddress)
       )
     )
+  }
+
+  implicit val arbPartnershipType: Arbitrary[PartnershipType] = Arbitrary {
+    for {
+      partnershipType <- Gen.oneOf(
+                           Seq(
+                             LimitedPartnership,
+                             LimitedLiabilityPartnership,
+                             GeneralPartnership,
+                             ScottishPartnership,
+                             ScottishLimitedPartnership
+                           )
+                         )
+    } yield PartnershipType(partnershipType)
   }
 
   def alphaNumericString: String = Gen.alphaNumStr.retryUntil(_.nonEmpty).sample.get

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
@@ -20,23 +20,25 @@ import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitr
 import org.scalacheck.Arbitrary
 import org.scalacheck.derive.MkArbitrary
 import uk.gov.hmrc.economiccrimelevyregistration.EclTestData
-import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisorType, BusinessSector, EntityType, SubscriptionStatus}
+import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisorType, BusinessSector, EclAddress, EntityType, SubscriptionStatus}
 import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.CreateEnrolmentRequest
-import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{RegistrationStatus, VerificationStatus}
+import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{IncorporatedEntityJourneyData, RegistrationStatus, VerificationStatus}
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.{Channel, EtmpSubscriptionStatus}
 
 object CachedArbitraries extends EclTestData {
 
   private def mkArb[T](implicit mkArb: MkArbitrary[T]): Arbitrary[T] = MkArbitrary[T].arbitrary
 
-  implicit lazy val arbChannel: Arbitrary[Channel]                               = mkArb
-  implicit lazy val arbCreateEnrolmentRequest: Arbitrary[CreateEnrolmentRequest] = mkArb
-  implicit lazy val arbAmlSupervisorType: Arbitrary[AmlSupervisorType]           = mkArb
-  implicit lazy val arbBusinessSector: Arbitrary[BusinessSector]                 = mkArb
-  implicit lazy val arbEntityType: Arbitrary[EntityType]                         = mkArb
-  implicit lazy val arbSubscriptionStatus: Arbitrary[SubscriptionStatus]         = mkArb
-  implicit lazy val arbRegistrationStatus: Arbitrary[RegistrationStatus]         = mkArb
-  implicit lazy val arbVerificationStatus: Arbitrary[VerificationStatus]         = mkArb
-  implicit lazy val arbEtmpSubscriptionStatus: Arbitrary[EtmpSubscriptionStatus] = mkArb
+  implicit lazy val arbChannel: Arbitrary[Channel]                                             = mkArb
+  implicit lazy val arbCreateEnrolmentRequest: Arbitrary[CreateEnrolmentRequest]               = mkArb
+  implicit lazy val arbAmlSupervisorType: Arbitrary[AmlSupervisorType]                         = mkArb
+  implicit lazy val arbBusinessSector: Arbitrary[BusinessSector]                               = mkArb
+  implicit lazy val arbEntityType: Arbitrary[EntityType]                                       = mkArb
+  implicit lazy val arbSubscriptionStatus: Arbitrary[SubscriptionStatus]                       = mkArb
+  implicit lazy val arbRegistrationStatus: Arbitrary[RegistrationStatus]                       = mkArb
+  implicit lazy val arbVerificationStatus: Arbitrary[VerificationStatus]                       = mkArb
+  implicit lazy val arbEtmpSubscriptionStatus: Arbitrary[EtmpSubscriptionStatus]               = mkArb
+  implicit lazy val arbIncorporatedEntityJourneyData: Arbitrary[IncorporatedEntityJourneyData] = mkArb
+  implicit lazy val arbEclAddress: Arbitrary[EclAddress]                                       = mkArb
 
 }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationControllerSpec.scala
@@ -63,7 +63,7 @@ class RegistrationValidationControllerSpec extends SpecBase {
           controller.getValidationErrors(registration.internalId)(fakeRequest)
 
         status(result)        shouldBe OK
-        contentAsJson(result) shouldBe Json.toJson(DataValidationErrors(Seq("Invalid data")))
+        contentAsJson(result) shouldBe Json.toJson(DataValidationErrors(Seq(DataValidationError("Invalid data"))))
     }
 
     "return 404 NOT_FOUND when there is no registration data to validate" in forAll { registration: Registration =>

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationControllerSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.controllers
+
+import cats.implicits._
+import org.mockito.ArgumentMatchers.any
+import play.api.libs.json.Json
+import play.api.mvc.Result
+import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
+import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.{DataValidationError, DataValidationErrors}
+import uk.gov.hmrc.economiccrimelevyregistration.repositories.RegistrationRepository
+import uk.gov.hmrc.economiccrimelevyregistration.services.RegistrationValidationService
+
+import scala.concurrent.Future
+
+class RegistrationValidationControllerSpec extends SpecBase {
+
+  val mockRegistrationValidationService: RegistrationValidationService = mock[RegistrationValidationService]
+  val mockRegistrationRepository: RegistrationRepository               = mock[RegistrationRepository]
+
+  val controller = new RegistrationValidationController(
+    cc,
+    mockRegistrationRepository,
+    fakeAuthorisedAction,
+    mockRegistrationValidationService
+  )
+
+  "validateRegistration" should {
+    "return 204 NO_CONTENT when the registration data is valid" in forAll { registration: Registration =>
+      when(mockRegistrationRepository.get(any())).thenReturn(Future.successful(Some(registration)))
+
+      when(mockRegistrationValidationService.validateRegistration(any())).thenReturn(registration.validNec)
+
+      val result: Future[Result] =
+        controller.validateRegistration(registration.internalId)(fakeRequest)
+
+      status(result) shouldBe NO_CONTENT
+    }
+
+    "return 200 OK with validation errors in the JSON response body when the registration data is invalid" in forAll {
+      registration: Registration =>
+        when(mockRegistrationRepository.get(any())).thenReturn(Future.successful(Some(registration)))
+
+        when(mockRegistrationValidationService.validateRegistration(any()))
+          .thenReturn(DataValidationError("Invalid data").invalidNec)
+
+        val result: Future[Result] =
+          controller.validateRegistration(registration.internalId)(fakeRequest)
+
+        status(result)        shouldBe OK
+        contentAsJson(result) shouldBe Json.toJson(DataValidationErrors(Seq("Invalid data")))
+    }
+
+    "return 404 NOT_FOUND when there is no registration data to validate" in forAll { registration: Registration =>
+      when(mockRegistrationRepository.get(any())).thenReturn(Future.successful(None))
+
+      val result: Future[Result] =
+        controller.validateRegistration(registration.internalId)(fakeRequest)
+
+      status(result) shouldBe NOT_FOUND
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationControllerSpec.scala
@@ -40,14 +40,14 @@ class RegistrationValidationControllerSpec extends SpecBase {
     mockRegistrationValidationService
   )
 
-  "validateRegistration" should {
+  "getValidationErrors" should {
     "return 204 NO_CONTENT when the registration data is valid" in forAll { registration: Registration =>
       when(mockRegistrationRepository.get(any())).thenReturn(Future.successful(Some(registration)))
 
       when(mockRegistrationValidationService.validateRegistration(any())).thenReturn(registration.validNec)
 
       val result: Future[Result] =
-        controller.validateRegistration(registration.internalId)(fakeRequest)
+        controller.getValidationErrors(registration.internalId)(fakeRequest)
 
       status(result) shouldBe NO_CONTENT
     }
@@ -60,7 +60,7 @@ class RegistrationValidationControllerSpec extends SpecBase {
           .thenReturn(DataValidationError("Invalid data").invalidNec)
 
         val result: Future[Result] =
-          controller.validateRegistration(registration.internalId)(fakeRequest)
+          controller.getValidationErrors(registration.internalId)(fakeRequest)
 
         status(result)        shouldBe OK
         contentAsJson(result) shouldBe Json.toJson(DataValidationErrors(Seq("Invalid data")))
@@ -70,7 +70,7 @@ class RegistrationValidationControllerSpec extends SpecBase {
       when(mockRegistrationRepository.get(any())).thenReturn(Future.successful(None))
 
       val result: Future[Result] =
-        controller.validateRegistration(registration.internalId)(fakeRequest)
+        controller.getValidationErrors(registration.internalId)(fakeRequest)
 
       status(result) shouldBe NOT_FOUND
     }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationServiceSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationServiceSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.services
+
+import cats.data.Validated.Valid
+import uk.gov.hmrc.economiccrimelevyregistration.ValidRegistration
+import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
+import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationError
+
+class RegistrationValidationServiceSpec extends SpecBase {
+  val service = new RegistrationValidationService()
+
+  "validateRegistration" should {
+    "return the registration if it is valid" in forAll { validRegistration: ValidRegistration =>
+      val result = service.validateRegistration(validRegistration.registration)
+
+      result shouldBe Valid(validRegistration.registration)
+    }
+
+    "return a non-empty chain of errors when unconditional mandatory registration data items are missing" in {
+      val registration = Registration.empty("internalId")
+
+      val expectedErrors = Seq(
+        DataValidationError("AML supervisor is missing"),
+        DataValidationError("Business sector is missing"),
+        DataValidationError("First contact name is missing"),
+        DataValidationError("First contact role is missing"),
+        DataValidationError("First contact email is missing"),
+        DataValidationError("First contact number is missing"),
+        DataValidationError("Contact address is missing"),
+        DataValidationError("Entity type is missing"),
+        DataValidationError("Second contact choice is missing")
+      )
+
+      val result = service.validateRegistration(registration)
+
+      result.isValid shouldBe false
+      result.leftMap(nec => nec.toNonEmptyList.toList should contain allElementsOf expectedErrors)
+    }
+
+    "return an error if the entity type is uk limited company but there is incorporated entity data in the registration" in {
+      pending
+    }
+
+    "return an error if the entity type is partnership but there is no partnership data in the registration" in {
+      pending
+    }
+
+    "return an error if the entity type is sole trader but there is no sole trader data in the registration" in {
+      pending
+    }
+
+    "return an error if the registration data does not contain the business partner ID" in {
+      pending
+    }
+
+    "return errors if the second contact choice is true and there are no second contact details in the registration data" in {
+      pending
+    }
+  }
+}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationServiceSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationServiceSpec.scala
@@ -17,10 +17,13 @@
 package uk.gov.hmrc.economiccrimelevyregistration.services
 
 import cats.data.Validated.Valid
-import uk.gov.hmrc.economiccrimelevyregistration.ValidRegistration
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
-import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
+import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType.SoleTrader
+import uk.gov.hmrc.economiccrimelevyregistration.models.{ContactDetails, Registration}
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationError
+import uk.gov.hmrc.economiccrimelevyregistration.models.grs.IncorporatedEntityJourneyData
+import uk.gov.hmrc.economiccrimelevyregistration.{PartnershipType, ValidRegistration}
 
 class RegistrationValidationServiceSpec extends SpecBase {
   val service = new RegistrationValidationService()
@@ -53,24 +56,82 @@ class RegistrationValidationServiceSpec extends SpecBase {
       result.leftMap(nec => nec.toNonEmptyList.toList should contain allElementsOf expectedErrors)
     }
 
-    "return an error if the entity type is uk limited company but there is incorporated entity data in the registration" in {
-      pending
+    "return an error if the entity type is uk limited company but there is no incorporated entity data in the registration" in forAll {
+      validRegistration: ValidRegistration =>
+        val invalidRegistration = validRegistration.registration.copy(incorporatedEntityJourneyData = None)
+
+        val result = service.validateRegistration(invalidRegistration)
+
+        result.isValid shouldBe false
+        result.leftMap(nec =>
+          nec.toNonEmptyList.toList should contain(DataValidationError("Incorporated entity data is missing"))
+        )
     }
 
-    "return an error if the entity type is partnership but there is no partnership data in the registration" in {
-      pending
+    "return an error if the entity type is partnership but there is no partnership data in the registration" in forAll {
+      (validRegistration: ValidRegistration, partnershipType: PartnershipType) =>
+        val invalidRegistration = validRegistration.registration
+          .copy(entityType = Some(partnershipType.entityType), partnershipEntityJourneyData = None)
+
+        val result = service.validateRegistration(invalidRegistration)
+
+        result.isValid shouldBe false
+        result.leftMap(nec =>
+          nec.toNonEmptyList.toList should contain(DataValidationError("Partnership data is missing"))
+        )
     }
 
-    "return an error if the entity type is sole trader but there is no sole trader data in the registration" in {
-      pending
+    "return an error if the entity type is sole trader but there is no sole trader data in the registration" in forAll {
+      (validRegistration: ValidRegistration) =>
+        val invalidRegistration = validRegistration.registration
+          .copy(entityType = Some(SoleTrader), soleTraderEntityJourneyData = None)
+
+        val result = service.validateRegistration(invalidRegistration)
+
+        result.isValid shouldBe false
+        result.leftMap(nec =>
+          nec.toNonEmptyList.toList should contain(DataValidationError("Sole trader data is missing"))
+        )
     }
 
-    "return an error if the registration data does not contain the business partner ID" in {
-      pending
+    "return an error if the registration data does not contain the business partner ID" in forAll {
+      (validRegistration: ValidRegistration, incorporatedEntityJourneyData: IncorporatedEntityJourneyData) =>
+        val invalidRegistration = validRegistration.registration
+          .copy(incorporatedEntityJourneyData =
+            Some(
+              incorporatedEntityJourneyData.copy(registration =
+                incorporatedEntityJourneyData.registration.copy(registeredBusinessPartnerId = None)
+              )
+            )
+          )
+
+        val result = service.validateRegistration(invalidRegistration)
+
+        result.isValid shouldBe false
+        result.leftMap(nec =>
+          nec.toNonEmptyList.toList should contain(DataValidationError("Business partner ID is missing"))
+        )
     }
 
-    "return errors if the second contact choice is true and there are no second contact details in the registration data" in {
-      pending
+    "return errors if the second contact choice is true and there are no second contact details in the registration data" in forAll {
+      (validRegistration: ValidRegistration) =>
+        val validContacts       = validRegistration.registration.contacts
+        val invalidRegistration = validRegistration.registration.copy(contacts =
+          validContacts.copy(secondContact = Some(true), secondContactDetails = ContactDetails(None, None, None, None))
+        )
+
+        val expectedErrors = Seq(
+          DataValidationError("Second contact name is missing"),
+          DataValidationError("Second contact role is missing"),
+          DataValidationError("Second contact email is missing"),
+          DataValidationError("Second contact number is missing")
+        )
+
+        val result = service.validateRegistration(invalidRegistration)
+
+        result.isValid shouldBe false
+        result.leftMap(nec => nec.toNonEmptyList.toList should contain allElementsOf expectedErrors)
     }
+
   }
 }


### PR DESCRIPTION
**Summary**

The motivation behind this API is so that it can be used independently by the frontend at any point to 'validate' the registration data and ensure it conforms to the expected business rules / data items that are required for submission to the HoD. It also means little to no validation/business logic is held in the frontend for the overall registration data set (the frontend still validates individual data items at the point of capture). In future work, which will involve submitting the data to the HoD, it can also be extended easily to do extra validation (such as JSON schema validation) at the point of submission.