### PR TITLE
ECL-251: Transform data into subscription model and validate against schema

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/IntegrationFrameworkConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/IntegrationFrameworkConnector.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.connectors
 import play.api.http.HeaderNames
 import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
 import uk.gov.hmrc.economiccrimelevyregistration.models.CustomHeaderNames
-import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.{CreateEclSubscriptionResponse, SubscriptionStatusResponse}
+import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.{CreateEclSubscriptionResponse, EclSubscription, SubscriptionStatusResponse}
 import uk.gov.hmrc.economiccrimelevyregistration.utils.CorrelationIdGenerator
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
@@ -48,11 +48,12 @@ class IntegrationFrameworkConnector @Inject() (
       headers = integrationFrameworkHeaders
     )
 
-  def subscribeToEcl(businessPartnerId: String)(implicit
+  def subscribeToEcl(eclSubscription: EclSubscription)(implicit
     hc: HeaderCarrier
   ): Future[CreateEclSubscriptionResponse] =
-    httpClient.POSTEmpty[CreateEclSubscriptionResponse](
-      s"${appConfig.integrationFrameworkUrl}/economic-crime-levy/subscriptions/ECL/create?idType=SAFE&idValue=$businessPartnerId",
+    httpClient.POST[EclSubscription, CreateEclSubscriptionResponse](
+      s"${appConfig.integrationFrameworkUrl}/economic-crime-levy/subscriptions/ECL/create?idType=SAFE&idValue=${eclSubscription.legalEntityDetails.safeId}",
+      eclSubscription,
       headers = integrationFrameworkHeaders
     )
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmissionController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmissionController.scala
@@ -47,7 +47,7 @@ class RegistrationSubmissionController @Inject() (
               Ok(Json.toJson(response))
             }
           case Invalid(e)             =>
-            Future.successful(InternalServerError(Json.toJson(DataValidationErrors(e.toNonEmptyList.toList))))
+            Future.successful(InternalServerError(Json.toJson(DataValidationErrors(e.toList))))
         }
       case None               => Future.successful(NotFound)
     }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmissionController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmissionController.scala
@@ -42,11 +42,11 @@ class RegistrationSubmissionController @Inject() (
     registrationRepository.get(id).flatMap {
       case Some(registration) =>
         registrationValidationService.validateRegistration(registration) match {
-          case Valid(id)  =>
-            subscriptionService.subscribeToEcl(id).map { response =>
+          case Valid(eclSubscription) =>
+            subscriptionService.subscribeToEcl(eclSubscription).map { response =>
               Ok(Json.toJson(response))
             }
-          case Invalid(e) =>
+          case Invalid(e)             =>
             Future.successful(InternalServerError(Json.toJson(DataValidationErrors(e.toNonEmptyList.toList))))
         }
       case None               => Future.successful(NotFound)

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationController.scala
@@ -42,7 +42,7 @@ class RegistrationValidationController @Inject() (
       case Some(registration) =>
         registrationValidationService.validateRegistration(registration) match {
           case Valid(_)   => NoContent
-          case Invalid(e) => Ok(Json.toJson(DataValidationErrors(e.toNonEmptyList.toList)))
+          case Invalid(e) => Ok(Json.toJson(DataValidationErrors(e.toList)))
         }
       case None               => NotFound
     }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/EntityType.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/EntityType.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.economiccrimelevyregistration.models
 
 import play.api.libs.json._
+import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType.SoleTrader
 
 sealed trait EntityType
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/EntityType.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/EntityType.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.economiccrimelevyregistration.models
 
 import play.api.libs.json._
-import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType.SoleTrader
 
 sealed trait EntityType
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/errors/DataValidationError.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/errors/DataValidationError.scala
@@ -21,8 +21,9 @@ import play.api.libs.json.{Json, OFormat}
 final case class DataValidationError(code: String, message: String, path: Option[String] = None)
 
 object DataValidationError {
-  val DataInvalid = "DATA_INVALID"
-  val DataMissing = "DATA_MISSING"
+  val SchemaValidationError = "SCHEMA_VALIDATION_ERROR"
+  val DataInvalid           = "DATA_INVALID"
+  val DataMissing           = "DATA_MISSING"
 
   implicit val format: OFormat[DataValidationError] = Json.format[DataValidationError]
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/errors/DataValidationError.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/errors/DataValidationError.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.models.errors
 
 import play.api.libs.json.{Json, OFormat}
 
-final case class DataValidationError(code: String, message: String, path: Option[String] = None)
+final case class DataValidationError(code: String, message: String)
 
 object DataValidationError {
   val SchemaValidationError = "SCHEMA_VALIDATION_ERROR"

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/integrationframework/EclSubscription.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/integrationframework/EclSubscription.scala
@@ -67,13 +67,14 @@ object CorrespondenceAddressDetails {
     postCode: Option[String],
     countryCode: String
   ): CorrespondenceAddressDetails = {
-    val groupedLines = (line1 +: otherLines).grouped(2).toSeq
+    def seqOptStringToString(seq: Seq[Option[String]]): Option[String] =
+      Option(seq.flatten.mkString(", ")).filter(_.nonEmpty)
 
     CorrespondenceAddressDetails(
-      addressLine1 = groupedLines.headOption.map(_.mkString(", ")).getOrElse(line1),
-      addressLine2 = groupedLines.lift(1).map(_.mkString(", ")),
-      addressLine3 = groupedLines.lift(2).map(_.mkString(", ")),
-      addressLine4 = groupedLines.lift(3).map(_.mkString(", ")),
+      addressLine1 = line1,
+      addressLine2 = seqOptStringToString(Seq(otherLines.headOption, otherLines.lift(3))),
+      addressLine3 = seqOptStringToString(Seq(otherLines.lift(1), otherLines.lift(4))),
+      addressLine4 = seqOptStringToString(Seq(otherLines.lift(2), otherLines.lift(5))),
       postCode = postCode,
       country = Some(countryCode)
     )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/integrationframework/EclSubscription.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/integrationframework/EclSubscription.scala
@@ -67,14 +67,24 @@ object CorrespondenceAddressDetails {
     postCode: Option[String],
     countryCode: String
   ): CorrespondenceAddressDetails = {
-    def seqOptStringToString(seq: Seq[Option[String]]): Option[String] =
+    val AddressLineMaxLength = 35
+
+    def seqOptLinesToString(seq: Seq[Option[String]]): Option[String] =
       Option(seq.flatten.mkString(", ")).filter(_.nonEmpty)
 
+    def overflow(optS: Option[String]): Option[String] =
+      optS.map(s => s.takeRight(Math.max(0, s.length - AddressLineMaxLength))).filter(_.nonEmpty)
+
+    val addressLine1 = line1
+    val addressLine2 = seqOptLinesToString(Seq(overflow(Some(line1)), otherLines.headOption, otherLines.lift(3)))
+    val addressLine3 = seqOptLinesToString(Seq(overflow(addressLine2), otherLines.lift(1), otherLines.lift(4)))
+    val addressLine4 = seqOptLinesToString(Seq(overflow(addressLine3), otherLines.lift(2), otherLines.lift(5)))
+
     CorrespondenceAddressDetails(
-      addressLine1 = line1,
-      addressLine2 = seqOptStringToString(Seq(otherLines.headOption, otherLines.lift(3))),
-      addressLine3 = seqOptStringToString(Seq(otherLines.lift(1), otherLines.lift(4))),
-      addressLine4 = seqOptStringToString(Seq(otherLines.lift(2), otherLines.lift(5))),
+      addressLine1 = addressLine1.take(AddressLineMaxLength),
+      addressLine2 = addressLine2.map(_.take(AddressLineMaxLength)),
+      addressLine3 = addressLine3.map(_.take(AddressLineMaxLength)),
+      addressLine4 = addressLine4.map(_.take(AddressLineMaxLength)),
       postCode = postCode,
       country = Some(countryCode)
     )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/integrationframework/EclSubscription.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/integrationframework/EclSubscription.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework
+
+import play.api.libs.json.{Json, OFormat}
+
+final case class EclSubscription(
+  legalEntityDetails: LegalEntityDetails,
+  correspondenceAddressDetails: CorrespondenceAddressDetails,
+  primaryContactDetails: SubscriptionContactDetails,
+  secondaryContactDetails: Option[SubscriptionContactDetails]
+)
+
+object EclSubscription {
+  implicit val format: OFormat[EclSubscription] = Json.format[EclSubscription]
+}
+
+final case class LegalEntityDetails(
+  safeId: String,
+  customerIdentification1: String,
+  customerIdentification2: Option[String],
+  organisationName: Option[String],
+  firstName: Option[String],
+  lastName: Option[String],
+  customerType: String,
+  registrationDate: String,
+  amlSupervisor: String,
+  businessSector: String
+)
+
+object LegalEntityDetails {
+  object CustomerType {
+    val Organisation = "01"
+    val Individual   = "02"
+  }
+
+  implicit val format: OFormat[LegalEntityDetails] = Json.format[LegalEntityDetails]
+}
+
+final case class CorrespondenceAddressDetails(
+  addressLine1: String,
+  addressLine2: Option[String],
+  addressLine3: Option[String],
+  addressLine4: Option[String],
+  postCode: Option[String],
+  country: Option[String]
+)
+
+object CorrespondenceAddressDetails {
+  def apply(
+    line1: String,
+    otherLines: Seq[String],
+    postCode: Option[String],
+    countryCode: String
+  ): CorrespondenceAddressDetails = {
+    val groupedLines = (line1 +: otherLines).grouped(2).toSeq
+
+    CorrespondenceAddressDetails(
+      addressLine1 = groupedLines.headOption.map(_.mkString(", ")).getOrElse(line1),
+      addressLine2 = groupedLines.lift(1).map(_.mkString(", ")),
+      addressLine3 = groupedLines.lift(2).map(_.mkString(", ")),
+      addressLine4 = groupedLines.lift(3).map(_.mkString(", ")),
+      postCode = postCode,
+      country = Some(countryCode)
+    )
+  }
+
+  implicit val format: OFormat[CorrespondenceAddressDetails] = Json.format[CorrespondenceAddressDetails]
+}
+
+final case class SubscriptionContactDetails(
+  name: String,
+  positionInCompany: String,
+  telephone: String,
+  emailAddress: String
+)
+
+object SubscriptionContactDetails {
+  implicit val format: OFormat[SubscriptionContactDetails] = Json.format[SubscriptionContactDetails]
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
@@ -42,7 +42,7 @@ class RegistrationValidationService @Inject() (clock: Clock, schemaValidator: Sc
       case Valid(eclSubscription) =>
         schemaValidator.validateAgainstJsonSchema(
           eclSubscription,
-          SchemaLoader.loadRequestSchema("create-ecl-subscription-request.json")
+          SchemaLoader.loadSchema("create-ecl-subscription-request.json")
         )
       case invalid                => invalid
     }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
@@ -18,77 +18,119 @@ package uk.gov.hmrc.economiccrimelevyregistration.services
 
 import cats.data.ValidatedNec
 import cats.implicits._
-import uk.gov.hmrc.economiccrimelevyregistration.models.AmlSupervisorType.{FinancialConductAuthority, GamblingCommission}
+import uk.gov.hmrc.economiccrimelevyregistration.models.AmlSupervisorType.{FinancialConductAuthority, GamblingCommission, Hmrc}
 import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType._
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationError
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationError._
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{IncorporatedEntityJourneyData, PartnershipEntityJourneyData, SoleTraderEntityJourneyData}
-import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisor, Registration}
+import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.LegalEntityDetails.CustomerType
+import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework._
+import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisor, ContactDetails, EclAddress, Registration}
 
+import java.time.format.DateTimeFormatter
+import java.time.{Clock, Instant, LocalDate, ZoneId}
 import javax.inject.Inject
 
-class RegistrationValidationService @Inject() () {
+class RegistrationValidationService @Inject() (clock: Clock) {
 
   type ValidationResult[A] = ValidatedNec[DataValidationError, A]
 
-  def validateRegistration(registration: Registration): ValidationResult[String] =
+  def validateRegistration(registration: Registration): ValidationResult[EclSubscription] =
     (
-      validateGrsJourneyData(registration),
-      validateAmlRegulatedActivity(registration),
+      validateLegalEntityDetails(registration),
       validateAmlSupervisor(registration),
-      validateOptExists(registration.relevantAp12Months, missingErrorMessage("Relevant AP 12 months choice")),
-      validateOptExists(registration.relevantApRevenue, missingErrorMessage("Relevant AP revenue")),
+      validateOptExists(registration.businessSector, "Business sector"),
+      validateFirstContactDetails(registration.contacts.firstContactDetails),
+      validateSecondContactDetails(registration),
+      validateEclAddress(registration.contactAddress),
+      validateAmlRegulatedActivity(registration),
+      validateOptExists(registration.relevantAp12Months, "Relevant AP 12 months choice"),
+      validateOptExists(registration.relevantApRevenue, "Relevant AP revenue"),
       validateConditionalOptExists(
         registration.relevantApLength,
         registration.relevantAp12Months.contains(false),
-        missingErrorMessage("Relevant AP length")
+        "Relevant AP length"
       ),
-      validateRevenueMeetsThreshold(registration),
-      validateOptExists(registration.contacts.firstContactDetails.name, missingErrorMessage("First contact name")),
-      validateOptExists(registration.contacts.firstContactDetails.role, missingErrorMessage("First contact role")),
-      validateOptExists(
-        registration.contacts.firstContactDetails.emailAddress,
-        missingErrorMessage("First contact email")
-      ),
-      validateOptExists(
-        registration.contacts.firstContactDetails.telephoneNumber,
-        missingErrorMessage("First contact number")
-      ),
-      validateOptExists(registration.businessSector, missingErrorMessage("Business sector")),
-      validateOptExists(registration.contactAddress, missingErrorMessage("Contact address")),
-      validateSecondContactDetails(registration),
-      validateConditionalOptExists(
-        registration.partnershipName,
-        registration.entityType.contains(GeneralPartnership) || registration.entityType.contains(ScottishPartnership),
-        missingErrorMessage("Partnership name")
-      )
-    ).mapN((businessPartnerId, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => businessPartnerId)
+      validateRevenueMeetsThreshold(registration)
+    ).mapN {
+      (
+        legalEntityDetails,
+        amlSupervisor,
+        businessSector,
+        firstContactDetails,
+        secondContactDetails,
+        contactAddress,
+        _,
+        _,
+        _,
+        _,
+        _
+      ) =>
+        val eclSubscription = EclSubscription(
+          legalEntityDetails = legalEntityDetails(amlSupervisor, businessSector.toString),
+          correspondenceAddressDetails = contactAddress,
+          primaryContactDetails = firstContactDetails,
+          secondaryContactDetails = secondContactDetails
+        )
 
-  private def validateSecondContactDetails(registration: Registration): ValidationResult[Registration] =
+        eclSubscription
+    }
+
+  private def validateFirstContactDetails(details: ContactDetails): ValidationResult[SubscriptionContactDetails] =
+    (
+      validateOptExists(details.name, "First contact name"),
+      validateOptExists(details.role, "First contact role"),
+      validateOptExists(
+        details.emailAddress,
+        "First contact email"
+      ),
+      validateOptExists(
+        details.telephoneNumber,
+        "First contact number"
+      )
+    ).mapN { (name, role, email, number) =>
+      SubscriptionContactDetails(name = name, positionInCompany = role, telephone = number, emailAddress = email)
+    }
+
+  private def validateSecondContactDetails(
+    registration: Registration
+  ): ValidationResult[Option[SubscriptionContactDetails]] =
     registration.contacts.secondContact match {
       case Some(true)  =>
         (
           validateOptExists(
             registration.contacts.secondContactDetails.name,
-            missingErrorMessage("Second contact name")
+            "Second contact name"
           ),
           validateOptExists(
             registration.contacts.secondContactDetails.role,
-            missingErrorMessage("Second contact role")
+            "Second contact role"
           ),
           validateOptExists(
             registration.contacts.secondContactDetails.emailAddress,
-            missingErrorMessage("Second contact email")
+            "Second contact email"
           ),
           validateOptExists(
             registration.contacts.secondContactDetails.telephoneNumber,
-            missingErrorMessage("Second contact number")
+            "Second contact number"
           )
-        ).mapN((_, _, _, _) => registration)
-      case Some(false) => registration.validNec
-      case _           => DataValidationError(missingErrorMessage("Second contact choice")).invalidNec
+        ).mapN((name, role, email, number) =>
+          Some(
+            SubscriptionContactDetails(
+              name = name,
+              positionInCompany = role,
+              telephone = number,
+              emailAddress = email
+            )
+          )
+        )
+      case Some(false) => None.validNec
+      case _           => DataValidationError(DataMissing, missingErrorMessage("Second contact choice")).invalidNec
     }
 
-  private def validateGrsJourneyData(registration: Registration): ValidationResult[String] = {
+  private def validateLegalEntityDetails(
+    registration: Registration
+  ): ValidationResult[(String, String) => LegalEntityDetails] = {
     val grsJourneyData: (
       Option[IncorporatedEntityJourneyData],
       Option[PartnershipEntityJourneyData],
@@ -99,62 +141,171 @@ class RegistrationValidationService @Inject() () {
       registration.soleTraderEntityJourneyData
     )
 
-    val validateBusinessPartnerId: Option[String] => ValidationResult[String] = {
-      case Some(s) => s.validNec
-      case _       => DataValidationError(missingErrorMessage("Business partner ID")).invalidNec
-    }
+    def registrationDate: String =
+      LocalDate.ofInstant(Instant.now(clock), ZoneId.systemDefault()).format(DateTimeFormatter.ISO_LOCAL_DATE)
 
     registration.entityType match {
-      case Some(UkLimitedCompany) =>
+      case Some(UkLimitedCompany)                                                              =>
         grsJourneyData match {
-          case (Some(i), None, None) => validateBusinessPartnerId(i.registration.registeredBusinessPartnerId)
-          case _                     => DataValidationError(missingErrorMessage("Incorporated entity data")).invalidNec
+          case (Some(i), None, None) =>
+            validateOptExists(i.registration.registeredBusinessPartnerId, "Business partner ID").map {
+              businessPartnerId =>
+                LegalEntityDetails(
+                  safeId = businessPartnerId,
+                  customerIdentification1 = i.ctutr,
+                  customerIdentification2 = Some(i.companyProfile.companyNumber),
+                  organisationName = Some(i.companyProfile.companyName),
+                  firstName = None,
+                  lastName = None,
+                  customerType = CustomerType.Organisation,
+                  registrationDate = registrationDate,
+                  _,
+                  _
+                )
+            }
+          case _                     => DataValidationError(DataMissing, missingErrorMessage("Incorporated entity data")).invalidNec
         }
-      case Some(
-            LimitedLiabilityPartnership | GeneralPartnership | ScottishPartnership | LimitedPartnership |
-            ScottishLimitedPartnership
-          ) =>
+      case Some(LimitedLiabilityPartnership | LimitedPartnership | ScottishLimitedPartnership) =>
         grsJourneyData match {
-          case (None, Some(p), None) => validateBusinessPartnerId(p.registration.registeredBusinessPartnerId)
-          case _                     => DataValidationError(missingErrorMessage("Partnership data")).invalidNec
+          case (None, Some(lp), None) =>
+            (
+              validateOptExists(lp.registration.registeredBusinessPartnerId, "Business partner ID"),
+              validateOptExists(lp.sautr, "Partnership SA UTR"),
+              validateOptExists(lp.companyProfile, "Partnership company profile")
+            ).mapN { (businessPartnerId, sautr, companyProfile) =>
+              LegalEntityDetails(
+                safeId = businessPartnerId,
+                customerIdentification1 = sautr,
+                customerIdentification2 = Some(companyProfile.companyNumber),
+                organisationName = Some(companyProfile.companyName),
+                firstName = None,
+                lastName = None,
+                customerType = CustomerType.Organisation,
+                registrationDate = registrationDate,
+                _,
+                _
+              )
+            }
+          case _                      => DataValidationError(DataMissing, missingErrorMessage("Partnership data")).invalidNec
         }
-      case Some(SoleTrader)       =>
+      case Some(GeneralPartnership | ScottishPartnership)                                      =>
         grsJourneyData match {
-          case (None, None, Some(s)) => validateBusinessPartnerId(s.registration.registeredBusinessPartnerId)
-          case _                     => DataValidationError(missingErrorMessage("Sole trader data")).invalidNec
+          case (None, Some(p), None) =>
+            (
+              validateOptExists(p.registration.registeredBusinessPartnerId, "Business partner ID"),
+              validateOptExists(p.sautr, "Partnership SA UTR"),
+              validateOptExists(p.postcode, "Partnership postcode"),
+              validateOptExists(registration.partnershipName, "Partnership name")
+            ).mapN { (businessPartnerId, sautr, postcode, partnershipName) =>
+              LegalEntityDetails(
+                safeId = businessPartnerId,
+                customerIdentification1 = sautr,
+                customerIdentification2 = Some(postcode),
+                organisationName = Some(partnershipName),
+                firstName = None,
+                lastName = None,
+                customerType = CustomerType.Organisation,
+                registrationDate = registrationDate,
+                _,
+                _
+              )
+            }
+          case _                     => DataValidationError(DataMissing, missingErrorMessage("Partnership data")).invalidNec
         }
-      case _                      => DataValidationError(missingErrorMessage("Entity type")).invalidNec
+      case Some(SoleTrader)                                                                    =>
+        grsJourneyData match {
+          case (None, None, Some(s)) =>
+            (
+              validateOptExists(s.registration.registeredBusinessPartnerId, "Business partner ID"),
+              validateSoleTraderIdentifiers(s)
+            ).mapN { (businessPartnerId, soleTraderIdentifiers) =>
+              LegalEntityDetails(
+                safeId = businessPartnerId,
+                customerIdentification1 = soleTraderIdentifiers._1,
+                customerIdentification2 = soleTraderIdentifiers._2,
+                organisationName = None,
+                firstName = Some(s.fullName.firstName),
+                lastName = Some(s.fullName.lastName),
+                customerType = CustomerType.Individual,
+                registrationDate = registrationDate,
+                _,
+                _
+              )
+            }
+          case _                     => DataValidationError(DataMissing, missingErrorMessage("Sole trader data")).invalidNec
+        }
+      case _                                                                                   =>
+        DataValidationError(DataMissing, missingErrorMessage("Entity type")).invalidNec
     }
+
   }
+
+  private def validateSoleTraderIdentifiers(
+    s: SoleTraderEntityJourneyData
+  ): ValidationResult[(String, Option[String])] =
+    (s.sautr, s.nino) match {
+      case (Some(sautr), Some(nino)) => (sautr, Some(nino)).validNec
+      case (Some(sautr), _)          => (sautr, None).validNec
+      case (_, Some(nino))           => (nino, None).validNec
+      case _                         => DataValidationError(DataMissing, missingErrorMessage("Sole trader SA UTR or NINO")).invalidNec
+    }
 
   private def validateAmlRegulatedActivity(registration: Registration): ValidationResult[Registration] =
     registration.carriedOutAmlRegulatedActivityInCurrentFy match {
       case Some(true)  => registration.validNec
-      case Some(false) => DataValidationError("Carried out AML regulated activity cannot be false").invalidNec
-      case _           => DataValidationError(missingErrorMessage("Carried out AML regulated activity choice")).invalidNec
+      case Some(false) =>
+        DataValidationError(DataInvalid, "Carried out AML regulated activity cannot be false").invalidNec
+      case _           =>
+        DataValidationError(DataMissing, missingErrorMessage("Carried out AML regulated activity choice")).invalidNec
     }
 
-  private def validateAmlSupervisor(registration: Registration): ValidationResult[Registration] =
+  private def validateAmlSupervisor(registration: Registration): ValidationResult[String] =
     registration.amlSupervisor match {
       case Some(AmlSupervisor(GamblingCommission | FinancialConductAuthority, _)) =>
-        DataValidationError("AML supervisor cannot be GC or FCA").invalidNec
-      case Some(_)                                                                => registration.validNec
-      case _                                                                      => DataValidationError(missingErrorMessage("AML supervisor")).invalidNec
+        DataValidationError(DataInvalid, "AML supervisor cannot be GC or FCA").invalidNec
+      case Some(AmlSupervisor(Hmrc, _))                                           => Hmrc.toString.validNec
+      case Some(AmlSupervisor(_, Some(otherProfessionalBody)))                    => otherProfessionalBody.validNec
+      case _                                                                      =>
+        DataValidationError(DataMissing, missingErrorMessage("AML supervisor")).invalidNec
     }
 
   private def validateRevenueMeetsThreshold(registration: Registration): ValidationResult[Registration] =
     registration.revenueMeetsThreshold match {
       case Some(true)  => registration.validNec
-      case Some(false) => DataValidationError("Revenue does not meet the liability threshold").invalidNec
-      case _           => DataValidationError(missingErrorMessage("Revenue meets threshold flag")).invalidNec
+      case Some(false) => DataValidationError(DataInvalid, "Revenue does not meet the liability threshold").invalidNec
+      case _           => DataValidationError(DataMissing, missingErrorMessage("Revenue meets threshold flag")).invalidNec
     }
 
-  private def missingErrorMessage(missingDataDescription: String): String = s"$missingDataDescription is missing"
+  private def validateEclAddress(eclAddress: Option[EclAddress]): ValidationResult[CorrespondenceAddressDetails] =
+    eclAddress match {
+      case Some(address) =>
+        val addressLines: Seq[String] = Seq(
+          address.organisation,
+          address.addressLine1,
+          address.addressLine2,
+          address.addressLine3,
+          address.addressLine4,
+          address.region,
+          address.poBox
+        ).flatMap(_.toSeq)
+
+        addressLines match {
+          case line1 :: otherLines =>
+            CorrespondenceAddressDetails(
+              line1,
+              otherLines,
+              address.postCode,
+              address.countryCode
+            ).validNec
+          case _                   => DataValidationError(DataInvalid, "Contact address has no address lines").invalidNec
+        }
+      case _             => DataValidationError(DataMissing, missingErrorMessage("Contact address")).invalidNec
+    }
 
   private def validateOptExists[T](optData: Option[T], description: String): ValidationResult[T] =
     optData match {
       case Some(value) => value.validNec
-      case _           => DataValidationError(description).invalidNec
+      case _           => DataValidationError(DataMissing, missingErrorMessage(description)).invalidNec
     }
 
   private def validateConditionalOptExists[T](
@@ -165,10 +316,12 @@ class RegistrationValidationService @Inject() () {
     if (condition) {
       optData match {
         case Some(value) => Some(value).validNec
-        case _           => DataValidationError(description).invalidNec
+        case _           => DataValidationError(DataMissing, missingErrorMessage(description)).invalidNec
       }
     } else {
       None.validNec
     }
+
+  private def missingErrorMessage(missingDataDescription: String): String = s"$missingDataDescription is missing"
 
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{IncorporatedEntityJ
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.LegalEntityDetails.CustomerType
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework._
 import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisor, ContactDetails, EclAddress, Registration}
-import uk.gov.hmrc.economiccrimelevyregistration.utils.SchemaValidator
+import uk.gov.hmrc.economiccrimelevyregistration.utils.{SchemaLoader, SchemaValidator}
 
 import java.time.format.DateTimeFormatter
 import java.time.{Clock, Instant, LocalDate, ZoneId}
@@ -40,7 +40,10 @@ class RegistrationValidationService @Inject() (clock: Clock, schemaValidator: Sc
   def validateRegistration(registration: Registration): ValidationResult[EclSubscription] =
     transformToEclSubscription(registration) match {
       case Valid(eclSubscription) =>
-        schemaValidator.validateAgainstJsonSchema(eclSubscription, "create-ecl-subscription-request.json")
+        schemaValidator.validateAgainstJsonSchema(
+          eclSubscription,
+          SchemaLoader.loadRequestSchema("create-ecl-subscription-request.json")
+        )
       case invalid                => invalid
     }
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/SubscriptionService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/SubscriptionService.scala
@@ -20,7 +20,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.connectors.{IntegrationFramewor
 import uk.gov.hmrc.economiccrimelevyregistration.models.KeyValue
 import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.CreateEnrolmentRequest
 import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.EclEnrolment._
-import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.CreateEclSubscriptionResponse
+import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.{CreateEclSubscriptionResponse, EclSubscription}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.ZoneId
@@ -32,8 +32,10 @@ class SubscriptionService @Inject() (
   integrationFrameworkConnector: IntegrationFrameworkConnector,
   taxEnrolmentsConnector: TaxEnrolmentsConnector
 )(implicit ec: ExecutionContext) {
-  def subscribeToEcl(id: String)(implicit hc: HeaderCarrier): Future[CreateEclSubscriptionResponse] =
-    integrationFrameworkConnector.subscribeToEcl(id).flatMap { response =>
+  def subscribeToEcl(
+    eclSubscription: EclSubscription
+  )(implicit hc: HeaderCarrier): Future[CreateEclSubscriptionResponse] =
+    integrationFrameworkConnector.subscribeToEcl(eclSubscription).flatMap { response =>
       taxEnrolmentsConnector.enrol(createEnrolmentRequest(response)).map(_ => response)
     }
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaLoader.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaLoader.scala
@@ -22,7 +22,7 @@ import scala.io.Source
 
 object SchemaLoader {
 
-  def loadRequestSchema(schemaFileName: String): Schema = {
+  def loadSchema(schemaFileName: String): Schema = {
     val schemaFilePath = s"/schemas/$schemaFileName"
     val resource       = getClass.getResourceAsStream(schemaFilePath)
     val source         = Source.fromInputStream(resource)

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaLoader.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaLoader.scala
@@ -14,21 +14,26 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.economiccrimelevyregistration.models.errors
+package uk.gov.hmrc.economiccrimelevyregistration.utils
 
-import play.api.libs.json.{Json, OFormat}
+import io.circe.schema.Schema
 
-final case class DataValidationError(code: String, message: String, path: Option[String] = None)
+import scala.io.Source
 
-object DataValidationError {
-  val DataInvalid = "DATA_INVALID"
-  val DataMissing = "DATA_MISSING"
+object SchemaLoader {
 
-  implicit val format: OFormat[DataValidationError] = Json.format[DataValidationError]
-}
+  def loadRequestSchema(schemaFileName: String): Schema = {
+    val schemaFilePath = s"/schemas/$schemaFileName"
+    val resource       = getClass.getResourceAsStream(schemaFilePath)
+    val source         = Source.fromInputStream(resource)
 
-final case class DataValidationErrors(errors: Seq[DataValidationError])
+    val jsonSchema =
+      try source.getLines().mkString
+      finally source.close()
 
-object DataValidationErrors {
-  implicit val format: OFormat[DataValidationErrors] = Json.format[DataValidationErrors]
+    Schema
+      .loadFromString(jsonSchema)
+      .get
+  }
+
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaValidator.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaValidator.scala
@@ -30,12 +30,11 @@ class SchemaValidator @Inject() () {
 
   type ValidationResult[A] = ValidatedNel[DataValidationError, A]
 
-  def validateAgainstJsonSchema[T](o: T, schemaName: String)(implicit
+  def validateAgainstJsonSchema[T](o: T, schema: Schema)(implicit
     format: OFormat[T]
   ): ValidationResult[T] = {
-    val schema: Schema = SchemaLoader.loadRequestSchema(schemaName)
-    val jsonString     = Json.toJson(o).toString()
-    val json           = circeParse(jsonString).getOrElse(
+    val jsonString = Json.toJson(o).toString()
+    val json       = circeParse(jsonString).getOrElse(
       throw new Exception("Could not transform play JSON into circe JSON for schema validation")
     )
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaValidator.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaValidator.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.utils
+
+import cats.data.Validated.{Invalid, Valid}
+import cats.data.ValidatedNel
+import io.circe.parser.{parse => circeParse}
+import io.circe.schema.Schema
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationError
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationError.SchemaValidationError
+
+import javax.inject.Inject
+
+class SchemaValidator @Inject() () {
+
+  type ValidationResult[A] = ValidatedNel[DataValidationError, A]
+
+  def validateAgainstJsonSchema[T](o: T, schemaName: String)(implicit
+    format: OFormat[T]
+  ): ValidationResult[T] = {
+    val schema: Schema = SchemaLoader.loadRequestSchema(schemaName)
+    val jsonString     = Json.toJson(o).toString()
+    val json           = circeParse(jsonString).getOrElse(
+      throw new Exception("Could not transform play JSON into circe JSON for schema validation")
+    )
+
+    schema
+      .validate(json) match {
+      case Valid(_)   => Valid(o)
+      case Invalid(e) =>
+        Invalid(
+          e.map(e =>
+            DataValidationError(
+              code = Option(e.keyword).getOrElse(SchemaValidationError),
+              message = e.getMessage,
+              path = Some(e.location)
+            )
+          )
+        )
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaValidator.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaValidator.scala
@@ -45,9 +45,8 @@ class SchemaValidator @Inject() () {
         Invalid(
           e.map(e =>
             DataValidationError(
-              code = Option(e.keyword).getOrElse(SchemaValidationError),
-              message = e.getMessage,
-              path = Some(e.location)
+              code = SchemaValidationError,
+              message = s"Schema validation error for field: ${e.location} (${Option(e.keyword).getOrElse("unknown")})"
             )
           )
         )

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,9 @@ lazy val root = (project in file("."))
   .settings(scoverageSettings: _*)
   .settings(scalaCompilerOptions: _*)
   .settings(
+    Compile / unmanagedResourceDirectories += baseDirectory.value / "resources",
+  )
+  .settings(
     scalaVersion := "2.13.8",
     name := appName,
     RoutesKeys.routesImport ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ val appName = "economic-crime-levy-registration"
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
-  .settings(SbtDistributablesPlugin.publishingSettings: _*)
   .settings(inConfig(Test)(testSettings): _*)
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(itSettings): _*)
@@ -57,7 +56,7 @@ val excludedScoveragePackages: Seq[String] = Seq(
   "app.*",
   "prod.*",
   ".*Routes.*",
-  "testOnly.*",
+  ".*testonly.*",
   "testOnlyDoNotUseInAppConf.*"
 )
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmissionISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmissionISpec.scala
@@ -10,7 +10,8 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.KeyValue
 import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.{CreateEnrolmentRequest, EclEnrolment}
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.CreateEclSubscriptionResponse
 
-import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, LocalDate}
 
 class RegistrationSubmissionISpec extends ISpecBase {
   s"POST ${routes.RegistrationSubmissionController.submitRegistration(":id").url}" should {
@@ -21,7 +22,15 @@ class RegistrationSubmissionISpec extends ISpecBase {
       val subscriptionResponse =
         random[CreateEclSubscriptionResponse].copy(processingDate = Instant.parse("2007-12-25T10:15:30.00Z"))
 
-      stubSubscribeToEcl(validRegistration.expectedBusinessPartnerId, subscriptionResponse)
+      val registrationDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
+
+      stubSubscribeToEcl(
+        validRegistration.expectedEclSubscription.copy(legalEntityDetails =
+          validRegistration.expectedEclSubscription.legalEntityDetails.copy(registrationDate = registrationDate)
+        ),
+        subscriptionResponse
+      )
+
       stubEnrol(
         CreateEnrolmentRequest(
           identifiers = Seq(KeyValue(key = EclEnrolment.IdentifierKey, value = subscriptionResponse.eclReference)),
@@ -43,7 +52,7 @@ class RegistrationSubmissionISpec extends ISpecBase {
         )
       )
 
-      status(result) shouldBe OK
+      status(result)        shouldBe OK
       contentAsJson(result) shouldBe Json.toJson(subscriptionResponse)
     }
   }

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmissionISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmissionISpec.scala
@@ -18,7 +18,7 @@ class RegistrationSubmissionISpec extends ISpecBase {
     "return 200 OK with a subscription reference number in the JSON response body when the registration data is valid" in {
       stubAuthorised()
 
-      val validRegistration    = random[ValidRegistration]
+      val validRegistration    = random[ValidUkCompanyRegistration]
       val subscriptionResponse =
         random[CreateEclSubscriptionResponse].copy(processingDate = Instant.parse("2007-12-25T10:15:30.00Z"))
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationValidationISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationValidationISpec.scala
@@ -31,7 +31,7 @@ class RegistrationValidationISpec extends ISpecBase {
     "return 204 NO_CONTENT when the registration data is valid" in {
       stubAuthorised()
 
-      val validRegistration = random[ValidRegistration]
+      val validRegistration = random[ValidUkCompanyRegistration]
 
       callRoute(
         FakeRequest(routes.RegistrationController.upsertRegistration).withJsonBody(

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationValidationISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationValidationISpec.scala
@@ -22,6 +22,7 @@ import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
 import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationError._
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.{DataValidationError, DataValidationErrors}
 
 class RegistrationValidationISpec extends ISpecBase {
@@ -63,19 +64,19 @@ class RegistrationValidationISpec extends ISpecBase {
         callRoute(FakeRequest(routes.RegistrationValidationController.getValidationErrors(internalId)))
 
       val expectedErrors = Seq(
-        DataValidationError("Carried out AML regulated activity choice is missing"),
-        DataValidationError("Relevant AP 12 months choice is missing"),
-        DataValidationError("Relevant AP revenue is missing"),
-        DataValidationError("Revenue meets threshold flag is missing"),
-        DataValidationError("AML supervisor is missing"),
-        DataValidationError("Business sector is missing"),
-        DataValidationError("First contact name is missing"),
-        DataValidationError("First contact role is missing"),
-        DataValidationError("First contact email is missing"),
-        DataValidationError("First contact number is missing"),
-        DataValidationError("Contact address is missing"),
-        DataValidationError("Entity type is missing"),
-        DataValidationError("Second contact choice is missing")
+        DataValidationError(DataMissing, "Carried out AML regulated activity choice is missing"),
+        DataValidationError(DataMissing, "Relevant AP 12 months choice is missing"),
+        DataValidationError(DataMissing, "Relevant AP revenue is missing"),
+        DataValidationError(DataMissing, "Revenue meets threshold flag is missing"),
+        DataValidationError(DataMissing, "AML supervisor is missing"),
+        DataValidationError(DataMissing, "Business sector is missing"),
+        DataValidationError(DataMissing, "First contact name is missing"),
+        DataValidationError(DataMissing, "First contact role is missing"),
+        DataValidationError(DataMissing, "First contact email is missing"),
+        DataValidationError(DataMissing, "First contact number is missing"),
+        DataValidationError(DataMissing, "Contact address is missing"),
+        DataValidationError(DataMissing, "Entity type is missing"),
+        DataValidationError(DataMissing, "Second contact choice is missing")
       )
 
       status(validationResult)                                      shouldBe OK

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/base/IntegrationFrameworkStubs.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/base/IntegrationFrameworkStubs.scala
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.libs.json.Json
 import uk.gov.hmrc.economiccrimelevyregistration.base.WireMockHelper._
-import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.CreateEclSubscriptionResponse
+import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.{CreateEclSubscriptionResponse, EclSubscription}
 
 trait IntegrationFrameworkStubs { self: WireMockStubs =>
 
@@ -13,8 +13,7 @@ trait IntegrationFrameworkStubs { self: WireMockStubs =>
       get(urlEqualTo(s"/cross-regime/subscription/ECL/SAFE/$testBusinessPartnerId/status")),
       aResponse()
         .withStatus(200)
-        .withBody(
-          s"""
+        .withBody(s"""
              |{
              |  "subscriptionStatus": "SUCCESSFUL",
              |  "idType": "ZECL",
@@ -29,17 +28,20 @@ trait IntegrationFrameworkStubs { self: WireMockStubs =>
       get(urlEqualTo(s"/cross-regime/subscription/ECL/SAFE/$testBusinessPartnerId/status")),
       aResponse()
         .withStatus(200)
-        .withBody(
-          s"""
+        .withBody(s"""
              |{
              |  "subscriptionStatus": "NO_FORM_BUNDLE_FOUND"
              |}
      """.stripMargin)
     )
 
-  def stubSubscribeToEcl(businessPartnerId: String, subscriptionResponse: CreateEclSubscriptionResponse): StubMapping =
+  def stubSubscribeToEcl(
+    eclSubscription: EclSubscription,
+    subscriptionResponse: CreateEclSubscriptionResponse
+  ): StubMapping =
     stub(
-      post(urlEqualTo(s"/economic-crime-levy/subscriptions/ECL/create?idType=SAFE&idValue=$businessPartnerId")),
+      post(urlEqualTo(s"/economic-crime-levy/subscriptions/ECL/create?idType=SAFE&idValue=${eclSubscription.legalEntityDetails.safeId}"))
+        .withRequestBody(equalToJson(Json.toJson(eclSubscription).toString())),
       aResponse()
         .withStatus(200)
         .withBody(Json.toJson(subscriptionResponse).toString())

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -11,12 +11,13 @@ object AppDependencies {
   )
 
   val test: Seq[ModuleID]    = Seq(
-    "uk.gov.hmrc"         %% "bootstrap-test-play-28"   % "7.12.0",
-    "uk.gov.hmrc.mongo"   %% "hmrc-mongo-test-play-28"  % "0.74.0",
-    "org.mockito"         %% "mockito-scala"            % "1.17.12",
-    "org.scalatestplus"   %% "scalatestplus-scalacheck" % "3.1.0.0-RC2",
-    "com.danielasfregola" %% "random-data-generator"    % "2.9",
-    "io.circe"            %% "circe-json-schema"        % "0.2.0"
+    "uk.gov.hmrc"          %% "bootstrap-test-play-28"   % "7.12.0",
+    "uk.gov.hmrc.mongo"    %% "hmrc-mongo-test-play-28"  % "0.74.0",
+    "org.mockito"          %% "mockito-scala"            % "1.17.12",
+    "org.scalatestplus"    %% "scalatestplus-scalacheck" % "3.1.0.0-RC2",
+    "com.danielasfregola"  %% "random-data-generator"    % "2.9",
+    "io.circe"             %% "circe-json-schema"        % "0.2.0",
+    "io.github.wolfendale" %% "scalacheck-gen-regexp"    % "1.1.0"
   ).map(_ % "test, it")
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,7 +5,9 @@ object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % "7.12.0",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % "0.74.0",
-    "org.typelevel"     %% "cats-core"                 % "2.9.0"
+    "org.typelevel"     %% "cats-core"                 % "2.9.0",
+    "io.circe"          %% "circe-json-schema"         % "0.2.0",
+    "io.circe"          %% "circe-parser"              % "0.14.1"
   )
 
   val test: Seq[ModuleID]    = Seq(
@@ -13,7 +15,8 @@ object AppDependencies {
     "uk.gov.hmrc.mongo"   %% "hmrc-mongo-test-play-28"  % "0.74.0",
     "org.mockito"         %% "mockito-scala"            % "1.17.12",
     "org.scalatestplus"   %% "scalatestplus-scalacheck" % "3.1.0.0-RC2",
-    "com.danielasfregola" %% "random-data-generator"    % "2.9"
+    "com.danielasfregola" %% "random-data-generator"    % "2.9",
+    "io.circe"            %% "circe-json-schema"        % "0.2.0"
   ).map(_ % "test, it")
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/resources/schemas/create-ecl-subscription-request.json
+++ b/resources/schemas/create-ecl-subscription-request.json
@@ -1,0 +1,475 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "legalEntityDetails",
+    "correspondenceAddressDetails",
+    "primaryContactDetails"
+  ],
+  "properties": {
+    "legalEntityDetails": {
+      "$ref": "#/definitions/legalEntityDetails_type"
+    },
+    "correspondenceAddressDetails": {
+      "$ref": "#/definitions/correspondenceAddressDetails_type"
+    },
+    "primaryContactDetails": {
+      "$ref": "#/definitions/primaryContactDetails_type"
+    },
+    "secondaryContactDetails": {
+      "$ref": "#/definitions/secondaryContactDetails_type"
+    }
+  },
+  "definitions": {
+    "amlSupervisor_type": {
+      "type": "string",
+      "description": "AML Supervisor",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "businessSector_type": {
+      "type": "string",
+      "description": "Business Sector",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "correspondenceAddressDetails_type": {
+      "type": "object",
+      "description": "Address details.",
+      "additionalProperties": false,
+      "required": [
+        "addressLine1"
+      ],
+      "properties": {
+        "addressLine1": {
+          "type": "string",
+          "description": "Address line 1",
+          "minLength": 1,
+          "maxLength": 35
+        },
+        "addressLine2": {
+          "type": "string",
+          "description": "Address line 2",
+          "minLength": 1,
+          "maxLength": 35
+        },
+        "addressLine3": {
+          "type": "string",
+          "description": "Address line 3",
+          "minLength": 1,
+          "maxLength": 35
+        },
+        "addressLine4": {
+          "type": "string",
+          "description": "Address line 4",
+          "minLength": 1,
+          "maxLength": 35
+        },
+        "postCode": {
+          "type": "string",
+          "description": "Postal code",
+          "minLength": 1,
+          "maxLength": 10
+        },
+        "country": {
+          "$ref": "#/definitions/country_code_type"
+        }
+      }
+    },
+    "country_code_type": {
+      "description": "Country Code.",
+      "type": "string",
+      "enum": [
+        "AD",
+        "AE",
+        "AF",
+        "AG",
+        "AI",
+        "AL",
+        "AM",
+        "AN",
+        "AO",
+        "AQ",
+        "AR",
+        "AS",
+        "AT",
+        "AU",
+        "AW",
+        "AX",
+        "AZ",
+        "BA",
+        "BB",
+        "BD",
+        "BE",
+        "BF",
+        "BG",
+        "BH",
+        "BI",
+        "BJ",
+        "BL",
+        "BM",
+        "BN",
+        "BO",
+        "BQ",
+        "BR",
+        "BS",
+        "BT",
+        "BV",
+        "BW",
+        "BY",
+        "BZ",
+        "CA",
+        "CC",
+        "CD",
+        "CF",
+        "CG",
+        "CH",
+        "CI",
+        "CK",
+        "CL",
+        "CM",
+        "CN",
+        "CO",
+        "CR",
+        "CS",
+        "CU",
+        "CV",
+        "CW",
+        "CX",
+        "CY",
+        "CZ",
+        "DE",
+        "DJ",
+        "DK",
+        "DM",
+        "DO",
+        "DZ",
+        "EC",
+        "EE",
+        "EG",
+        "EH",
+        "ER",
+        "ES",
+        "ET",
+        "EU",
+        "FC",
+        "FI",
+        "FJ",
+        "FK",
+        "FM",
+        "FO",
+        "FR",
+        "GA",
+        "GB",
+        "GD",
+        "GE",
+        "GF",
+        "GG",
+        "GH",
+        "GI",
+        "GL",
+        "GM",
+        "GN",
+        "GP",
+        "GQ",
+        "GR",
+        "GS",
+        "GT",
+        "GU",
+        "GW",
+        "GY",
+        "HK",
+        "HM",
+        "HN",
+        "HR",
+        "HT",
+        "HU",
+        "ID",
+        "IE",
+        "IL",
+        "IM",
+        "IN",
+        "IO",
+        "IQ",
+        "IR",
+        "IS",
+        "IT",
+        "JE",
+        "JM",
+        "JO",
+        "JP",
+        "KE",
+        "KG",
+        "KH",
+        "KI",
+        "KM",
+        "KN",
+        "KP",
+        "KR",
+        "KW",
+        "KY",
+        "KZ",
+        "LA",
+        "LB",
+        "LC",
+        "LI",
+        "LK",
+        "LR",
+        "LS",
+        "LT",
+        "LU",
+        "LV",
+        "LY",
+        "MA",
+        "MC",
+        "MD",
+        "ME",
+        "MF",
+        "MG",
+        "MH",
+        "MK",
+        "ML",
+        "MM",
+        "MN",
+        "MO",
+        "MP",
+        "MQ",
+        "MR",
+        "MS",
+        "MT",
+        "MU",
+        "MV",
+        "MW",
+        "MX",
+        "MY",
+        "MZ",
+        "NA",
+        "NC",
+        "NE",
+        "NF",
+        "NG",
+        "NI",
+        "NL",
+        "NO",
+        "NP",
+        "NR",
+        "NT",
+        "NU",
+        "NZ",
+        "OM",
+        "OR",
+        "PA",
+        "PE",
+        "PF",
+        "PG",
+        "PH",
+        "PK",
+        "PL",
+        "PM",
+        "PN",
+        "PR",
+        "PS",
+        "PT",
+        "PW",
+        "PY",
+        "QA",
+        "RE",
+        "RO",
+        "RS",
+        "RU",
+        "RW",
+        "SA",
+        "SB",
+        "SC",
+        "SD",
+        "SE",
+        "SG",
+        "SH",
+        "SI",
+        "SJ",
+        "SK",
+        "SL",
+        "SM",
+        "SN",
+        "SO",
+        "SR",
+        "SS",
+        "ST",
+        "SV",
+        "SX",
+        "SY",
+        "SZ",
+        "TC",
+        "TD",
+        "TF",
+        "TG",
+        "TH",
+        "TJ",
+        "TK",
+        "TL",
+        "TM",
+        "TN",
+        "TO",
+        "TP",
+        "TR",
+        "TT",
+        "TV",
+        "TW",
+        "TZ",
+        "UA",
+        "UG",
+        "UM",
+        "UN",
+        "US",
+        "UY",
+        "UZ",
+        "VA",
+        "VC",
+        "VE",
+        "VG",
+        "VI",
+        "VN",
+        "VU",
+        "WF",
+        "WS",
+        "YE",
+        "YT",
+        "ZA",
+        "ZM",
+        "ZW",
+        "ZZ"
+      ]
+    },
+    "date_type": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-([0][1-9]|[1][0-2])-([0][1-9]|[1-2][0-9]|[3][0-1])$"
+    },
+    "email_type": {
+      "type": "string",
+      "pattern": "^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$"
+    },
+    "legalEntityDetails_type": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "safeId",
+        "customerIdentification1",
+        "customerType",
+        "registrationDate",
+        "amlSupervisor",
+        "businessSector"
+      ],
+      "properties": {
+        "safeId": {
+          "type": "string",
+          "description": "Safe ID",
+          "pattern": "X[A-Z]{1}[0-9]{13}"
+        },
+        "customerIdentification1": {
+          "type": "string",
+          "description": "Customer Identification1",
+          "pattern": "^[0-9]{15}$"
+        },
+        "customerIdentification2": {
+          "type": "string",
+          "description": "Customer Identification2",
+          "pattern": "^[0-9]{15}$"
+        },
+        "customerType": {
+          "type": "string",
+          "description": "Customer Type=01 :Show Organisation Name or Customer Type=02 :Show Firstname & Lastname",
+          "enum": [
+            "01",
+            "02"
+          ]
+        },
+        "organisationName": {
+          "type": "string",
+          "description": "Populate Only if customerType=1",
+          "minLength": 1,
+          "maxLength": 160
+        },
+        "firstName": {
+          "type": "string",
+          "description": "Populate Only if customerType=2",
+          "minLength": 1,
+          "maxLength": 35
+        },
+        "lastName": {
+          "type": "string",
+          "description": "Populate Only if customerType=2",
+          "minLength": 1,
+          "maxLength": 35
+        },
+        "registrationDate": {
+          "description": "Date of Registration",
+          "$ref": "#/definitions/date_type"
+        },
+        "amlSupervisor": {
+          "$ref": "#/definitions/amlSupervisor_type"
+        },
+        "businessSector": {
+          "$ref": "#/definitions/businessSector_type"
+        }
+      }
+    },
+    "primaryContactDetails_type": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "positionInCompany",
+        "telephone",
+        "emailAddress"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name",
+          "minLength": 1,
+          "maxLength": 160
+        },
+        "positionInCompany": {
+          "type": "string",
+          "description": "Position in Company",
+          "minLength": 1,
+          "maxLength": 160
+        },
+        "telephone": {
+          "$ref": "#/definitions/telephone_type"
+        },
+        "emailAddress": {
+          "$ref": "#/definitions/email_type"
+        }
+      }
+    },
+    "secondaryContactDetails_type": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name",
+          "minLength": 1,
+          "maxLength": 160
+        },
+        "positionInCompany": {
+          "type": "string",
+          "description": "Position in Company",
+          "minLength": 1,
+          "maxLength": 160
+        },
+        "telephone": {
+          "$ref": "#/definitions/telephone_type"
+        },
+        "emailAddress": {
+          "$ref": "#/definitions/email_type"
+        }
+      }
+    },
+    "telephone_type": {
+      "type": "string",
+      "pattern": "^(?:(?:\\(?(?:00|\\+)([1-4]\\d\\d|[1-9]\\d?)\\)?)?[\\-\\.\\ \\/]?)?((?:\\(?\\d{1,}\\)?[\\-\\.\\ \\/]?){0,})(?:[\\-\\.\\ \\/]?(?:#|ext\\.?|extension|x)[\\-\\.\\ \\/]?(\\d+))?$"
+    }
+  }
+}

--- a/resources/schemas/create-ecl-subscription-request.json
+++ b/resources/schemas/create-ecl-subscription-request.json
@@ -368,12 +368,12 @@
         "customerIdentification1": {
           "type": "string",
           "description": "Customer Identification1",
-          "pattern": "^[0-9]{15}$"
+          "pattern": "^[a-zA-Z0-9]{1,15}$"
         },
         "customerIdentification2": {
           "type": "string",
           "description": "Customer Identification2",
-          "pattern": "^[0-9]{15}$"
+          "pattern": "^[a-zA-Z0-9]{1,15}$"
         },
         "customerType": {
           "type": "string",

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -87,7 +87,7 @@
     </check>
     <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
         <parameters>
-            <parameter name="maximum"><![CDATA[15]]></parameter>
+            <parameter name="maximum"><![CDATA[20]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
@@ -100,7 +100,7 @@
     </check>
     <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
         <parameters>
-            <parameter name="maxLength"><![CDATA[50]]></parameter>
+            <parameter name="maxLength"><![CDATA[200]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
@@ -291,7 +291,7 @@ trait EclTestData {
         LegalEntityDetails(
           safeId = businessPartnerId,
           customerIdentification1 = sautr,
-          customerIdentification2 = Some(companyProfile.companyName),
+          customerIdentification2 = Some(companyProfile.companyNumber),
           organisationName = Some(companyProfile.companyName),
           firstName = None,
           lastName = None,

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
@@ -167,12 +167,19 @@ trait EclTestData {
       country = Some("GB")
     )
 
+  implicit val arbCompanyProfile: Arbitrary[CompanyProfile] = Arbitrary {
+    for {
+      companyProfile <- MkArbitrary[CompanyProfile].arbitrary.arbitrary
+      companyName    <- stringsWithMaxLength(160)
+      companyNumber  <- RegexpGen.from(Regex.customerIdentificationNumber)
+    } yield companyProfile.copy(companyName = companyName, companyNumber = companyNumber)
+  }
+
   implicit val arbValidUkCompanyRegistration: Arbitrary[ValidUkCompanyRegistration] = Arbitrary {
     for {
       businessPartnerId             <- RegexpGen.from(Regex.businessPartnerId)
       incorporatedEntityJourneyData <- Arbitrary.arbitrary[IncorporatedEntityJourneyData]
       ctutr                         <- RegexpGen.from(Regex.customerIdentificationNumber)
-      companyNumber                 <- RegexpGen.from(Regex.customerIdentificationNumber)
       commonRegistrationData        <- Arbitrary.arbitrary[CommonRegistrationData]
     } yield ValidUkCompanyRegistration(
       commonRegistrationData.registration.copy(
@@ -180,7 +187,6 @@ trait EclTestData {
         incorporatedEntityJourneyData = Some(
           incorporatedEntityJourneyData.copy(
             ctutr = ctutr,
-            companyProfile = incorporatedEntityJourneyData.companyProfile.copy(companyNumber = companyNumber),
             registration =
               incorporatedEntityJourneyData.registration.copy(registeredBusinessPartnerId = Some(businessPartnerId))
           )
@@ -192,7 +198,7 @@ trait EclTestData {
         LegalEntityDetails(
           safeId = businessPartnerId,
           customerIdentification1 = ctutr,
-          customerIdentification2 = Some(companyNumber),
+          customerIdentification2 = Some(incorporatedEntityJourneyData.companyProfile.companyNumber),
           organisationName = Some(incorporatedEntityJourneyData.companyProfile.companyName),
           firstName = None,
           lastName = None,
@@ -265,7 +271,6 @@ trait EclTestData {
       partnershipEntityJourneyData <- Arbitrary.arbitrary[PartnershipEntityJourneyData]
       companyProfile               <- Arbitrary.arbitrary[CompanyProfile]
       sautr                        <- RegexpGen.from(Regex.customerIdentificationNumber)
-      companyNumber                <- RegexpGen.from(Regex.customerIdentificationNumber)
       commonRegistrationData       <- Arbitrary.arbitrary[CommonRegistrationData]
       partnershipType              <- Arbitrary.arbitrary[LimitedPartnershipType]
     } yield ValidLimitedPartnershipRegistration(
@@ -275,7 +280,7 @@ trait EclTestData {
         partnershipEntityJourneyData = Some(
           partnershipEntityJourneyData.copy(
             sautr = Some(sautr),
-            companyProfile = Some(companyProfile.copy(companyNumber = companyNumber)),
+            companyProfile = Some(companyProfile),
             registration =
               partnershipEntityJourneyData.registration.copy(registeredBusinessPartnerId = Some(businessPartnerId))
           )
@@ -286,7 +291,7 @@ trait EclTestData {
         LegalEntityDetails(
           safeId = businessPartnerId,
           customerIdentification1 = sautr,
-          customerIdentification2 = Some(companyNumber),
+          customerIdentification2 = Some(companyProfile.companyName),
           organisationName = Some(companyProfile.companyName),
           firstName = None,
           lastName = None,

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
@@ -159,10 +159,10 @@ trait EclTestData {
 
   private def commonCorrespondenceAddressDetails: CorrespondenceAddressDetails =
     CorrespondenceAddressDetails(
-      addressLine1 = "Test Org Name, Test Address Line 1",
-      addressLine2 = Some("Test Address Line 2, Test Region"),
-      addressLine3 = None,
-      addressLine4 = None,
+      addressLine1 = "Test Org Name",
+      addressLine2 = Some("Test Address Line 1"),
+      addressLine3 = Some("Test Address Line 2"),
+      addressLine4 = Some("Test Region"),
       postCode = Some("AB12 3DE"),
       country = Some("GB")
     )

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/Regex.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/Regex.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration
+
+object Regex {
+
+  val telephoneNumber              =
+    "^(?:(?:\\(?(?:00|\\+)([1-4]\\d\\d|[1-9]\\d?)\\)?)?[\\-\\.\\ \\/]?)?((?:\\(?\\d{1,}\\)?[\\-\\.\\ \\/]?){0,})(?:[\\-\\.\\ \\/]?(?:#|ext\\.?|extension|x)[\\-\\.\\ \\/]?(\\d+))?$"
+  val customerIdentificationNumber = "^[a-zA-Z0-9]{1,15}$"
+  val businessPartnerId            = "X[A-Z]{1}[0-9]{13}"
+
+}

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
@@ -22,8 +22,8 @@ import org.scalacheck.derive.MkArbitrary
 import uk.gov.hmrc.economiccrimelevyregistration.EclTestData
 import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisorType, BusinessSector, EclAddress, EntityType, SubscriptionStatus}
 import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.CreateEnrolmentRequest
-import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{IncorporatedEntityJourneyData, PartnershipEntityJourneyData, RegistrationStatus, VerificationStatus}
-import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.{Channel, CreateEclSubscriptionResponse, EtmpSubscriptionStatus}
+import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{IncorporatedEntityJourneyData, PartnershipEntityJourneyData, RegistrationStatus, SoleTraderEntityJourneyData, VerificationStatus}
+import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.{Channel, CreateEclSubscriptionResponse, EclSubscription, EtmpSubscriptionStatus}
 
 object CachedArbitraries extends EclTestData {
 
@@ -40,7 +40,9 @@ object CachedArbitraries extends EclTestData {
   implicit lazy val arbEtmpSubscriptionStatus: Arbitrary[EtmpSubscriptionStatus]               = mkArb
   implicit lazy val arbIncorporatedEntityJourneyData: Arbitrary[IncorporatedEntityJourneyData] = mkArb
   implicit lazy val arbPartnershipEntityJourneyData: Arbitrary[PartnershipEntityJourneyData]   = mkArb
+  implicit lazy val arbSoleTraderEntityJourneyData: Arbitrary[SoleTraderEntityJourneyData]     = mkArb
   implicit lazy val arbEclAddress: Arbitrary[EclAddress]                                       = mkArb
   implicit lazy val arbCreateEclSubscriptionResponse: Arbitrary[CreateEclSubscriptionResponse] = mkArb
+  implicit lazy val arbEclSubscription: Arbitrary[EclSubscription]                             = mkArb
 
 }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmissionControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmissionControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
-import cats.implicits.catsSyntaxValidatedIdBinCompat0
+import cats.implicits.catsSyntaxValidatedId
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.libs.json.Json
@@ -55,7 +55,7 @@ class RegistrationSubmissionControllerSpec extends SpecBase {
       ) =>
         when(mockRegistrationRepository.get(any())).thenReturn(Future.successful(Some(registration)))
 
-        when(mockRegistrationValidationService.validateRegistration(any())).thenReturn(eclSubscription.validNec)
+        when(mockRegistrationValidationService.validateRegistration(any())).thenReturn(eclSubscription.validNel)
 
         when(mockSubscriptionServiceService.subscribeToEcl(ArgumentMatchers.eq(eclSubscription))(any()))
           .thenReturn(Future.successful(subscriptionResponse))
@@ -72,7 +72,7 @@ class RegistrationSubmissionControllerSpec extends SpecBase {
         when(mockRegistrationRepository.get(any())).thenReturn(Future.successful(Some(registration)))
 
         when(mockRegistrationValidationService.validateRegistration(any()))
-          .thenReturn(DataValidationError(DataInvalid, "Invalid data").invalidNec)
+          .thenReturn(DataValidationError(DataInvalid, "Invalid data").invalidNel)
 
         val result: Future[Result] =
           controller.submitRegistration(registration.internalId)(fakeRequest)

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationValidationControllerSpec.scala
@@ -48,7 +48,7 @@ class RegistrationValidationControllerSpec extends SpecBase {
       (registration: Registration, eclSubscription: EclSubscription) =>
         when(mockRegistrationRepository.get(any())).thenReturn(Future.successful(Some(registration)))
 
-        when(mockRegistrationValidationService.validateRegistration(any())).thenReturn(eclSubscription.validNec)
+        when(mockRegistrationValidationService.validateRegistration(any())).thenReturn(eclSubscription.validNel)
 
         val result: Future[Result] =
           controller.getValidationErrors(registration.internalId)(fakeRequest)
@@ -61,7 +61,7 @@ class RegistrationValidationControllerSpec extends SpecBase {
         when(mockRegistrationRepository.get(any())).thenReturn(Future.successful(Some(registration)))
 
         when(mockRegistrationValidationService.validateRegistration(any()))
-          .thenReturn(DataValidationError(DataInvalid, "Invalid data").invalidNec)
+          .thenReturn(DataValidationError(DataInvalid, "Invalid data").invalidNel)
 
         val result: Future[Result] =
           controller.getValidationErrors(registration.internalId)(fakeRequest)

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/models/CorrespondenceAddressDetailsSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/models/CorrespondenceAddressDetailsSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.models
+
+import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
+import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.CorrespondenceAddressDetails
+
+class CorrespondenceAddressDetailsSpec extends SpecBase {
+  private val organisation: String     = "Test organisation"
+  private val addressLine1: String     = "Test line 1"
+  private val addressLine2: String     = "Test line 2"
+  private val addressLine3: String     = "Test line 3"
+  private val addressLine4: String     = "Test line 4"
+  private val region: String           = "Test region"
+  private val postcode: Option[String] = Some("AB12 3CD")
+  private val poBox: String            = "PO box 123"
+  private val countryCode: String      = "GB"
+  private val longAddressLine1: String = "Test line 1 that is longer than 35 characters"
+  private val longAddressLine2: String = "Test line 2 that is longer than 35 characters"
+  private val longAddressLine3: String = "Test line 3 that is longer than 35 characters"
+  private val longAddressLine4: String = "Test line 4 that is longer than 35 characters"
+
+  val lines1: (String, Seq[String]) = (organisation, Seq(addressLine1, addressLine2, region))
+  val lines2: (String, Seq[String]) =
+    (organisation, Seq(addressLine1, addressLine2, addressLine3, addressLine4, region, poBox))
+  val lines3: (String, Seq[String]) =
+    (addressLine1, Seq(addressLine2, addressLine3, addressLine4))
+  val lines4: (String, Seq[String]) =
+    (longAddressLine1, Seq(addressLine2, addressLine3, addressLine4))
+  val lines5: (String, Seq[String]) =
+    (longAddressLine1, Seq(longAddressLine2, longAddressLine3, longAddressLine4))
+
+  val correspondenceAddressDetails1: CorrespondenceAddressDetails = CorrespondenceAddressDetails(
+    addressLine1 = organisation,
+    addressLine2 = Some(addressLine1),
+    addressLine3 = Some(addressLine2),
+    addressLine4 = Some(region),
+    postCode = postcode,
+    country = Some(countryCode)
+  )
+
+  val correspondenceAddressDetails2: CorrespondenceAddressDetails = CorrespondenceAddressDetails(
+    addressLine1 = organisation,
+    addressLine2 = Some(s"$addressLine1, $addressLine4"),
+    addressLine3 = Some(s"$addressLine2, $region"),
+    addressLine4 = Some(s"$addressLine3, $poBox"),
+    postCode = postcode,
+    country = Some(countryCode)
+  )
+
+  val correspondenceAddressDetails3: CorrespondenceAddressDetails = CorrespondenceAddressDetails(
+    addressLine1 = addressLine1,
+    addressLine2 = Some(addressLine2),
+    addressLine3 = Some(addressLine3),
+    addressLine4 = Some(addressLine4),
+    postCode = postcode,
+    country = Some(countryCode)
+  )
+
+  val correspondenceAddressDetails4: CorrespondenceAddressDetails = CorrespondenceAddressDetails(
+    addressLine1 = "Test line 1 that is longer than 35 ",
+    addressLine2 = Some(s"characters, $addressLine2"),
+    addressLine3 = Some(addressLine3),
+    addressLine4 = Some(addressLine4),
+    postCode = postcode,
+    country = Some(countryCode)
+  )
+
+  val correspondenceAddressDetails5: CorrespondenceAddressDetails = CorrespondenceAddressDetails(
+    addressLine1 = "Test line 1 that is longer than 35 ",
+    addressLine2 = Some("characters, Test line 2 that is lon"),
+    addressLine3 = Some("ger than 35 characters, Test line 3"),
+    addressLine4 = Some(" that is longer than 35 characters,"),
+    postCode = postcode,
+    country = Some(countryCode)
+  )
+
+  "apply" should {
+    "construct correspondence address details from the given address lines, postcode and country code" in forAll(
+      Table(
+        ("lines", "correspondenceAddressDetails"),
+        (lines1, correspondenceAddressDetails1),
+        (lines2, correspondenceAddressDetails2),
+        (lines3, correspondenceAddressDetails3),
+        (lines4, correspondenceAddressDetails4),
+        (lines5, correspondenceAddressDetails5)
+      )
+    ) { (lines: (String, Seq[String]), correspondenceAddressDetails: CorrespondenceAddressDetails) =>
+      CorrespondenceAddressDetails(lines._1, lines._2, postcode, countryCode) shouldBe correspondenceAddressDetails
+    }
+
+  }
+
+}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationServiceSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationServiceSpec.scala
@@ -48,7 +48,7 @@ class RegistrationValidationServiceSpec extends SpecBase {
       when(
         mockSchemaValidator.validateAgainstJsonSchema(
           ArgumentMatchers.eq(validRegistration.expectedEclSubscription),
-          ArgumentMatchers.eq("create-ecl-subscription-request.json")
+          any()
         )(any())
       ).thenReturn(validRegistration.expectedEclSubscription.validNel)
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationServiceSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationServiceSpec.scala
@@ -21,6 +21,7 @@ import cats.implicits.catsSyntaxValidatedId
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.scalacheck.{Arbitrary, Gen}
+import uk.gov.hmrc.economiccrimelevyregistration._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models.AmlSupervisorType.{FinancialConductAuthority, GamblingCommission}
@@ -30,7 +31,6 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationErr
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{IncorporatedEntityJourneyData, PartnershipEntityJourneyData, SoleTraderEntityJourneyData}
 import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisor, AmlSupervisorType, ContactDetails, Registration}
 import uk.gov.hmrc.economiccrimelevyregistration.utils.SchemaValidator
-import uk.gov.hmrc.economiccrimelevyregistration.{LimitedPartnershipType, PartnershipType, ScottishOrGeneralPartnershipType, ValidUkCompanyRegistration}
 
 import java.time.{Clock, Instant, ZoneId}
 
@@ -44,18 +44,60 @@ class RegistrationValidationServiceSpec extends SpecBase {
   val service = new RegistrationValidationService(stubClock, mockSchemaValidator)
 
   "validateRegistration" should {
-    "return the ECL subscription if the registration is valid" in forAll {
-      validRegistration: ValidUkCompanyRegistration =>
+    "return the ECL subscription if the registration for a UK company is valid" in forAll {
+      validUkCompanyRegistration: ValidUkCompanyRegistration =>
         when(
           mockSchemaValidator.validateAgainstJsonSchema(
-            ArgumentMatchers.eq(validRegistration.expectedEclSubscription),
+            ArgumentMatchers.eq(validUkCompanyRegistration.expectedEclSubscription),
             any()
           )(any())
-        ).thenReturn(validRegistration.expectedEclSubscription.validNel)
+        ).thenReturn(validUkCompanyRegistration.expectedEclSubscription.validNel)
 
-        val result = service.validateRegistration(validRegistration.registration)
+        val result = service.validateRegistration(validUkCompanyRegistration.registration)
 
-        result shouldBe Valid(validRegistration.expectedEclSubscription)
+        result shouldBe Valid(validUkCompanyRegistration.expectedEclSubscription)
+    }
+
+    "return the ECL subscription if the registration for a sole trader is valid" in forAll {
+      validSoleTraderRegistration: ValidSoleTraderRegistration =>
+        when(
+          mockSchemaValidator.validateAgainstJsonSchema(
+            ArgumentMatchers.eq(validSoleTraderRegistration.expectedEclSubscription),
+            any()
+          )(any())
+        ).thenReturn(validSoleTraderRegistration.expectedEclSubscription.validNel)
+
+        val result = service.validateRegistration(validSoleTraderRegistration.registration)
+
+        result shouldBe Valid(validSoleTraderRegistration.expectedEclSubscription)
+    }
+
+    "return the ECL subscription if the registration for a limited partnership is valid" in forAll {
+      validLimitedPartnershipRegistration: ValidLimitedPartnershipRegistration =>
+        when(
+          mockSchemaValidator.validateAgainstJsonSchema(
+            ArgumentMatchers.eq(validLimitedPartnershipRegistration.expectedEclSubscription),
+            any()
+          )(any())
+        ).thenReturn(validLimitedPartnershipRegistration.expectedEclSubscription.validNel)
+
+        val result = service.validateRegistration(validLimitedPartnershipRegistration.registration)
+
+        result shouldBe Valid(validLimitedPartnershipRegistration.expectedEclSubscription)
+    }
+
+    "return the ECL subscription if the registration for a scottish or general partnership is valid" in forAll {
+      validScottishOrGeneralPartnershipRegistration: ValidScottishOrGeneralPartnershipRegistration =>
+        when(
+          mockSchemaValidator.validateAgainstJsonSchema(
+            ArgumentMatchers.eq(validScottishOrGeneralPartnershipRegistration.expectedEclSubscription),
+            any()
+          )(any())
+        ).thenReturn(validScottishOrGeneralPartnershipRegistration.expectedEclSubscription.validNel)
+
+        val result = service.validateRegistration(validScottishOrGeneralPartnershipRegistration.registration)
+
+        result shouldBe Valid(validScottishOrGeneralPartnershipRegistration.expectedEclSubscription)
     }
 
     "return a non-empty chain of errors when unconditional mandatory registration data items are missing" in {

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/services/SubscriptionServiceSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/services/SubscriptionServiceSpec.scala
@@ -21,29 +21,29 @@ import org.mockito.ArgumentMatchers.any
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.{IntegrationFrameworkConnector, TaxEnrolmentsConnector}
 import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
-import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.CreateEclSubscriptionResponse
+import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.{CreateEclSubscriptionResponse, EclSubscription}
 
 import scala.concurrent.Future
 
 class SubscriptionServiceSpec extends SpecBase {
-  val mockIntegrationFrameworkConnector = mock[IntegrationFrameworkConnector]
-  val mockTaxEnrolmentsConnector        = mock[TaxEnrolmentsConnector]
+  val mockIntegrationFrameworkConnector: IntegrationFrameworkConnector = mock[IntegrationFrameworkConnector]
+  val mockTaxEnrolmentsConnector: TaxEnrolmentsConnector               = mock[TaxEnrolmentsConnector]
 
   val service = new SubscriptionService(mockIntegrationFrameworkConnector, mockTaxEnrolmentsConnector)
 
   "subscribeToEcl" should {
     "return the ECL reference number" in forAll {
       (
-        businessPartnerId: String,
+        eclSubscription: EclSubscription,
         subscriptionResponse: CreateEclSubscriptionResponse
       ) =>
-        when(mockIntegrationFrameworkConnector.subscribeToEcl(ArgumentMatchers.eq(businessPartnerId))(any()))
+        when(mockIntegrationFrameworkConnector.subscribeToEcl(ArgumentMatchers.eq(eclSubscription))(any()))
           .thenReturn(Future.successful(subscriptionResponse))
 
         when(mockTaxEnrolmentsConnector.enrol(any())(any()))
           .thenReturn(Future.successful(()))
 
-        val result = await(service.subscribeToEcl(businessPartnerId))
+        val result = await(service.subscribeToEcl(eclSubscription))
 
         result shouldBe subscriptionResponse
     }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaValidatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaValidatorSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.utils
+
+import cats.data.Validated.Valid
+import io.circe.schema.Schema
+import play.api.libs.json._
+import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationError
+
+class SchemaValidatorSpec extends SpecBase {
+  case class TestObject(foo: String, bar: String)
+
+  object TestObject {
+    implicit val format: OFormat[TestObject] = Json.format[TestObject]
+  }
+
+  private val testJsonSchema: Schema = Schema
+    .loadFromString("""{
+        |  "$schema": "http://json-schema.org/draft-07/schema#",
+        |  "title": "TestObject",
+        |  "type": "object",
+        |  "properties": {
+        |    "foo": {
+        |      "type": "string",
+        |      "description": "A string value"
+        |    },
+        |    "bar": {
+        |      "type": "string",
+        |      "description": "A string value",
+        |      "pattern": "^[a-z]*$"
+        |    }
+        |  }
+        |}""".stripMargin)
+    .getOrElse(fail("failed to create test JSON schema"))
+
+  val schemaValidator: SchemaValidator = new SchemaValidator
+
+  "validateAgainstJsonSchema" should {
+    "serialize an object into JSON and validate it against a JSON schema, returning the given validated object if there are no errors" in {
+      val result = schemaValidator.validateAgainstJsonSchema(TestObject("foo", "bar"), testJsonSchema)
+
+      result shouldBe Valid(TestObject("foo", "bar"))
+    }
+
+    "serialize an object into JSON and validate it against a JSON schema, returning errors if there are any" in {
+      val result = schemaValidator.validateAgainstJsonSchema(TestObject("foo", "123"), testJsonSchema)
+
+      result.isValid shouldBe false
+      result.leftMap(nec =>
+        nec.toList should contain only DataValidationError(
+          "pattern",
+          "#/bar: string [123] does not match pattern ^[a-z]*$",
+          Some("#/bar")
+        )
+      )
+    }
+  }
+}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaValidatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/utils/SchemaValidatorSpec.scala
@@ -21,6 +21,7 @@ import io.circe.schema.Schema
 import play.api.libs.json._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationError
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationError.SchemaValidationError
 
 class SchemaValidatorSpec extends SpecBase {
   case class TestObject(foo: String, bar: String)
@@ -63,9 +64,8 @@ class SchemaValidatorSpec extends SpecBase {
       result.isValid shouldBe false
       result.leftMap(nec =>
         nec.toList should contain only DataValidationError(
-          "pattern",
-          "#/bar: string [123] does not match pattern ^[a-z]*$",
-          Some("#/bar")
+          SchemaValidationError,
+          "Schema validation error for field: #/bar (pattern)"
         )
       )
     }


### PR DESCRIPTION
The validation is now a 2-step process:

- Firstly we validate all of the answers and data items we expect are present and any other conditional validation is applied, transforming the data into the subscription data model for ETMP
- Secondly we apply schema validation on the serialised JSON that will be sent to ETMP
- If both steps pass, then the submission to ETMP can be made