### PR TITLE
Implement work-item-repo to retry upserting known facts for failed enrolments

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/config/AppConfig.scala
@@ -16,9 +16,11 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.config
 
-import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration.FiniteDuration
 
 @Singleton
 class AppConfig @Inject() (configuration: Configuration, servicesConfig: ServicesConfig) {
@@ -36,4 +38,9 @@ class AppConfig @Inject() (configuration: Configuration, servicesConfig: Service
 
   val integrationFrameworkEnvironment: String =
     configuration.get[String]("microservice.services.integration-framework.environment")
+
+  val enrolmentStoreProxyBaseUrl: String = servicesConfig.baseUrl("enrolment-store-proxy")
+
+  val knownFactsInProgressRetryAfter: FiniteDuration =
+    configuration.get[FiniteDuration]("knownFactsQueue.inProgressRetryAfter")
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EnrolmentStoreProxyConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EnrolmentStoreProxyConnector.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.connectors
+
+import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
+import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.{EclEnrolment, UpsertKnownFactsRequest}
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, UpstreamErrorResponse}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+trait EnrolmentStoreProxyConnector {
+  def upsertKnownFacts(upsertKnownFactsRequest: UpsertKnownFactsRequest, eclReference: String)(implicit
+    hc: HeaderCarrier
+  ): Future[Either[UpstreamErrorResponse, HttpResponse]]
+}
+
+@Singleton
+class EnrolmentStoreProxyConnectorImpl @Inject() (appConfig: AppConfig, httpClient: HttpClient)(implicit
+  ec: ExecutionContext
+) extends EnrolmentStoreProxyConnector {
+
+  private val enrolmentStoreUrl: String =
+    s"${appConfig.enrolmentStoreProxyBaseUrl}/enrolment-store-proxy/enrolment-store"
+
+  def upsertKnownFacts(upsertKnownFactsRequest: UpsertKnownFactsRequest, eclReference: String)(implicit
+    hc: HeaderCarrier
+  ): Future[Either[UpstreamErrorResponse, HttpResponse]] = {
+    val enrolmentKey = s"${EclEnrolment.ServiceName}~${EclEnrolment.IdentifierKey}~$eclReference"
+
+    httpClient.PUT[UpsertKnownFactsRequest, Either[UpstreamErrorResponse, HttpResponse]](
+      s"$enrolmentStoreUrl/enrolments/$enrolmentKey",
+      upsertKnownFactsRequest
+    )
+  }
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EnrolmentStoreProxyConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EnrolmentStoreProxyConnector.scala
@@ -40,12 +40,9 @@ class EnrolmentStoreProxyConnectorImpl @Inject() (appConfig: AppConfig, httpClie
 
   def upsertKnownFacts(upsertKnownFactsRequest: UpsertKnownFactsRequest, eclReference: String)(implicit
     hc: HeaderCarrier
-  ): Future[Either[UpstreamErrorResponse, HttpResponse]] = {
-    val enrolmentKey = s"${EclEnrolment.ServiceName}~${EclEnrolment.IdentifierKey}~$eclReference"
-
+  ): Future[Either[UpstreamErrorResponse, HttpResponse]] =
     httpClient.PUT[UpsertKnownFactsRequest, Either[UpstreamErrorResponse, HttpResponse]](
-      s"$enrolmentStoreUrl/enrolments/$enrolmentKey",
+      s"$enrolmentStoreUrl/enrolments/${EclEnrolment.EnrolmentKey(eclReference)}",
       upsertKnownFactsRequest
     )
-  }
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/IntegrationFrameworkConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/IntegrationFrameworkConnector.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.connectors
 import play.api.http.HeaderNames
 import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
 import uk.gov.hmrc.economiccrimelevyregistration.models.CustomHeaderNames
-import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.{CreateEclSubscriptionResponse, EclSubscription, Subscription, SubscriptionStatusResponse}
+import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework._
 import uk.gov.hmrc.economiccrimelevyregistration.utils.CorrelationIdGenerator
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
@@ -34,7 +34,7 @@ class IntegrationFrameworkConnector @Inject() (
   correlationIdGenerator: CorrelationIdGenerator
 )(implicit ec: ExecutionContext) {
 
-  def integrationFrameworkHeaders: Seq[(String, String)] = Seq(
+  private def integrationFrameworkHeaders: Seq[(String, String)] = Seq(
     (HeaderNames.AUTHORIZATION, s"Bearer ${appConfig.integrationFrameworkBearerToken}"),
     (CustomHeaderNames.Environment, appConfig.integrationFrameworkEnvironment),
     (CustomHeaderNames.CorrelationId, correlationIdGenerator.generateCorrelationId)

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/TaxEnrolmentsConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/TaxEnrolmentsConnector.scala
@@ -31,14 +31,12 @@ class TaxEnrolmentsConnector @Inject() (appConfig: AppConfig, httpClient: HttpCl
   private val taxEnrolmentsUrl: String =
     s"${appConfig.taxEnrolmentsBaseUrl}/tax-enrolments/service/$ServiceName/enrolment"
 
-  def enrol(createEnrolmentRequest: CreateEnrolmentRequest)(implicit hc: HeaderCarrier): Future[Unit] =
+  def enrol(
+    createEnrolmentRequest: CreateEnrolmentRequest
+  )(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, HttpResponse]] =
     httpClient
       .PUT[CreateEnrolmentRequest, Either[UpstreamErrorResponse, HttpResponse]](
         taxEnrolmentsUrl,
         createEnrolmentRequest
       )
-      .map {
-        case Left(e)  => throw e
-        case Right(_) => ()
-      }
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/KnownFactsWorkItem.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/KnownFactsWorkItem.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.models
+
+import play.api.libs.json.{Json, OFormat}
+
+final case class KnownFactsWorkItem(eclReference: String, eclRegistrationDate: String)
+
+object KnownFactsWorkItem {
+  implicit val format: OFormat[KnownFactsWorkItem] = Json.format[KnownFactsWorkItem]
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/eacd/UpsertKnownFactsRequest.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/eacd/UpsertKnownFactsRequest.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.models.eacd
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.economiccrimelevyregistration.models.KeyValue
+
+final case class UpsertKnownFactsRequest(
+  verifiers: Seq[KeyValue]
+)
+
+object UpsertKnownFactsRequest {
+  implicit val format: OFormat[UpsertKnownFactsRequest] = Json.format[UpsertKnownFactsRequest]
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/repositories/KnownFactsQueueRepository.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/repositories/KnownFactsQueueRepository.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.repositories
+
+import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
+import uk.gov.hmrc.economiccrimelevyregistration.models.KnownFactsWorkItem
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.workitem.{WorkItemFields, WorkItemRepository}
+
+import java.time.{Duration, Instant}
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+import scala.jdk.DurationConverters.ScalaDurationOps
+
+@Singleton
+class KnownFactsQueueRepository @Inject() (
+  config: AppConfig,
+  mongoComponent: MongoComponent
+)(implicit ec: ExecutionContext)
+    extends WorkItemRepository[KnownFactsWorkItem](
+      collectionName = "knownFactsWorkItems",
+      mongoComponent = mongoComponent,
+      itemFormat = KnownFactsWorkItem.format,
+      workItemFields = WorkItemFields.default
+    ) {
+  override def now(): Instant =
+    Instant.now()
+
+  override val inProgressRetryAfter: Duration = config.knownFactsInProgressRetryAfter.toJava
+
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/KnownFactsQueuePullScheduler.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/KnownFactsQueuePullScheduler.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.services
+
+import akka.actor.ActorSystem
+import play.api.Logging
+import uk.gov.hmrc.economiccrimelevyregistration.connectors.EnrolmentStoreProxyConnector
+import uk.gov.hmrc.economiccrimelevyregistration.models.KeyValue
+import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.{EclEnrolment, UpsertKnownFactsRequest}
+import uk.gov.hmrc.economiccrimelevyregistration.repositories.KnownFactsQueueRepository
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.mongo.workitem.ProcessingStatus
+
+import java.time.Instant
+import javax.inject.Inject
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, Future}
+
+class KnownFactsQueuePullScheduler @Inject() (
+  actorSystem: ActorSystem,
+  knownFactsQueueRepository: KnownFactsQueueRepository,
+  enrolmentStoreProxyConnector: EnrolmentStoreProxyConnector
+)(implicit executionContext: ExecutionContext)
+    extends Logging {
+
+  actorSystem.scheduler.scheduleAtFixedRate(initialDelay = 10.seconds, interval = 1.minute) { () =>
+    processKnownFacts
+  }
+
+  def processKnownFacts: Future[Unit] = {
+    logger.info("Processing known facts for failed enrolments")
+
+    knownFactsQueueRepository
+      .pullOutstanding(
+        Instant.now(),
+        Instant.now()
+      )
+      .flatMap {
+        case None                     =>
+          logger.info("No known facts to process for failed enrolments")
+          Future.unit
+        case Some(knownFactsWorkItem) =>
+          enrolmentStoreProxyConnector
+            .upsertKnownFacts(
+              UpsertKnownFactsRequest(
+                verifiers = Seq(KeyValue(EclEnrolment.VerifierKey, knownFactsWorkItem.item.eclRegistrationDate))
+              ),
+              knownFactsWorkItem.item.eclReference
+            )(HeaderCarrier())
+            .map {
+              case Left(e)  =>
+                logger.error(s"Failed to upsert known facts for failed enrolment: ${e.message}")
+                knownFactsQueueRepository.markAs(knownFactsWorkItem.id, ProcessingStatus.Failed)
+              case Right(_) =>
+                logger.info("Successfully upserted known facts for failed enrolment")
+                knownFactsQueueRepository.completeAndDelete(knownFactsWorkItem.id)
+            }
+      }
+  }
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/SubscriptionService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/SubscriptionService.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.{KeyValue, KnownFactsWor
 import uk.gov.hmrc.economiccrimelevyregistration.repositories.KnownFactsQueueRepository
 import uk.gov.hmrc.http.HeaderCarrier
 
-import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
@@ -37,7 +37,7 @@ class SubscriptionService @Inject() (
 )(implicit ec: ExecutionContext)
     extends Logging {
 
-  private val dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneId.systemDefault())
+  private val dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneOffset.UTC)
 
   def subscribeToEcl(
     eclSubscription: EclSubscription

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/testonly/connectors/StubEnrolmentStoreProxyConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/testonly/connectors/StubEnrolmentStoreProxyConnector.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.testonly.connectors
+
+import play.api.http.Status.NO_CONTENT
+import uk.gov.hmrc.economiccrimelevyregistration.connectors.EnrolmentStoreProxyConnector
+import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.UpsertKnownFactsRequest
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, UpstreamErrorResponse}
+
+import javax.inject.Inject
+import scala.concurrent.Future
+
+class StubEnrolmentStoreProxyConnector @Inject() extends EnrolmentStoreProxyConnector {
+  override def upsertKnownFacts(upsertKnownFactsRequest: UpsertKnownFactsRequest, eclReference: String)(implicit
+    hc: HeaderCarrier
+  ): Future[Either[UpstreamErrorResponse, HttpResponse]] =
+    Future.successful(Right(HttpResponse(NO_CONTENT, "", Map.empty)))
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -90,6 +90,10 @@ mongodb {
   timeToLiveInSeconds = 2592000
 }
 
+knownFactsQueue {
+  inProgressRetryAfter = 20s
+}
+
 microservice {
   metrics {
     graphite {
@@ -103,23 +107,32 @@ microservice {
   services {
     auth {
       protocol = http
-      host     = localhost
-      port     = 8500
+      host = localhost
+      port = 8500
     }
 
     tax-enrolments {
       protocol = http
-      host     = localhost
-      port     = 9995
+      host = localhost
+      port = 9995
+    }
+
+    enrolment-store-proxy {
+      protocol = http
+      host = localhost
+      port = 7775
     }
 
     integration-framework {
       protocol = http
-      host     = localhost
-      port     = 14004
+      host = localhost
+      port = 14004
       bearerToken = test
       environment = test
     }
   }
 }
 
+features {
+  enrolmentStoreProxyStubEnabled = true
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -91,7 +91,7 @@ mongodb {
 }
 
 knownFactsQueue {
-  inProgressRetryAfter = 20s
+  inProgressRetryAfter = 30s
 }
 
 microservice {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,6 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-backend-play-28"         % "7.12.0",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"                % "0.74.0",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-work-item-repo-play-28" % "0.74.0",
     "org.typelevel"     %% "cats-core"                         % "2.9.0",
     "io.circe"          %% "circe-json-schema"                 % "0.2.0",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,11 +3,12 @@ import sbt._
 object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % "7.12.0",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % "0.74.0",
-    "org.typelevel"     %% "cats-core"                 % "2.9.0",
-    "io.circe"          %% "circe-json-schema"         % "0.2.0",
-    "io.circe"          %% "circe-parser"              % "0.14.1"
+    "uk.gov.hmrc"       %% "bootstrap-backend-play-28"         % "7.12.0",
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"                % "0.74.0",
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-work-item-repo-play-28" % "0.74.0",
+    "org.typelevel"     %% "cats-core"                         % "2.9.0",
+    "io.circe"          %% "circe-json-schema"                 % "0.2.0",
+    "io.circe"          %% "circe-parser"                      % "0.14.1"
   )
 
   val test: Seq[ModuleID]    = Seq(

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
@@ -17,9 +17,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
 import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import org.bson.types.ObjectId
 import org.scalacheck.Gen.{choose, listOfN}
 import org.scalacheck.derive.MkArbitrary
 import org.scalacheck.{Arbitrary, Gen}
+import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK}
 import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models.AmlSupervisorType.Hmrc
 import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType._
@@ -27,6 +29,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models._
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{CompanyProfile, IncorporatedEntityJourneyData, PartnershipEntityJourneyData, SoleTraderEntityJourneyData}
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.EtmpSubscriptionStatus._
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework._
+import uk.gov.hmrc.http.{HttpResponse, UpstreamErrorResponse}
 import wolfendale.scalacheck.regexp.RegexpGen
 
 import java.time.{Instant, LocalDate}
@@ -406,6 +409,18 @@ trait EclTestData {
                                   )
                                 )
     } yield LimitedPartnershipType(limitedPartnershipType)
+  }
+
+  implicit val arbUpstreamErrorResponse: Arbitrary[UpstreamErrorResponse] = Arbitrary {
+    UpstreamErrorResponse("Internal server error", INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR)
+  }
+
+  implicit val arbSuccessfulHttpResponse: Arbitrary[HttpResponse] = Arbitrary {
+    HttpResponse(OK, "", Map.empty)
+  }
+
+  implicit val arbObjectId: Arbitrary[ObjectId] = Arbitrary {
+    ObjectId.get()
   }
 
   def alphaNumericString: String = Gen.alphaNumStr.retryUntil(_.nonEmpty).sample.get

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
@@ -20,29 +20,34 @@ import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitr
 import org.scalacheck.Arbitrary
 import org.scalacheck.derive.MkArbitrary
 import uk.gov.hmrc.economiccrimelevyregistration.EclTestData
-import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisorType, BusinessSector, EclAddress, EntityType, SubscriptionStatus}
-import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.CreateEnrolmentRequest
+import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisorType, BusinessSector, EclAddress, EntityType, KnownFactsWorkItem, SubscriptionStatus}
+import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.{CreateEnrolmentRequest, UpsertKnownFactsRequest}
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{IncorporatedEntityJourneyData, PartnershipEntityJourneyData, RegistrationStatus, SoleTraderEntityJourneyData, VerificationStatus}
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.{Channel, CreateEclSubscriptionResponse, EclSubscription, EtmpSubscriptionStatus}
+import uk.gov.hmrc.http.{HttpResponse, UpstreamErrorResponse}
+import uk.gov.hmrc.mongo.workitem.WorkItem
 
 object CachedArbitraries extends EclTestData {
 
   private def mkArb[T](implicit mkArb: MkArbitrary[T]): Arbitrary[T] = MkArbitrary[T].arbitrary
 
-  implicit lazy val arbChannel: Arbitrary[Channel]                                             = mkArb
-  implicit lazy val arbCreateEnrolmentRequest: Arbitrary[CreateEnrolmentRequest]               = mkArb
-  implicit lazy val arbAmlSupervisorType: Arbitrary[AmlSupervisorType]                         = mkArb
-  implicit lazy val arbBusinessSector: Arbitrary[BusinessSector]                               = mkArb
-  implicit lazy val arbEntityType: Arbitrary[EntityType]                                       = mkArb
-  implicit lazy val arbSubscriptionStatus: Arbitrary[SubscriptionStatus]                       = mkArb
-  implicit lazy val arbRegistrationStatus: Arbitrary[RegistrationStatus]                       = mkArb
-  implicit lazy val arbVerificationStatus: Arbitrary[VerificationStatus]                       = mkArb
-  implicit lazy val arbEtmpSubscriptionStatus: Arbitrary[EtmpSubscriptionStatus]               = mkArb
-  implicit lazy val arbIncorporatedEntityJourneyData: Arbitrary[IncorporatedEntityJourneyData] = mkArb
-  implicit lazy val arbPartnershipEntityJourneyData: Arbitrary[PartnershipEntityJourneyData]   = mkArb
-  implicit lazy val arbSoleTraderEntityJourneyData: Arbitrary[SoleTraderEntityJourneyData]     = mkArb
-  implicit lazy val arbEclAddress: Arbitrary[EclAddress]                                       = mkArb
-  implicit lazy val arbCreateEclSubscriptionResponse: Arbitrary[CreateEclSubscriptionResponse] = mkArb
-  implicit lazy val arbEclSubscription: Arbitrary[EclSubscription]                             = mkArb
+  implicit lazy val arbChannel: Arbitrary[Channel]                                                       = mkArb
+  implicit lazy val arbCreateEnrolmentRequest: Arbitrary[CreateEnrolmentRequest]                         = mkArb
+  implicit lazy val arbAmlSupervisorType: Arbitrary[AmlSupervisorType]                                   = mkArb
+  implicit lazy val arbBusinessSector: Arbitrary[BusinessSector]                                         = mkArb
+  implicit lazy val arbEntityType: Arbitrary[EntityType]                                                 = mkArb
+  implicit lazy val arbSubscriptionStatus: Arbitrary[SubscriptionStatus]                                 = mkArb
+  implicit lazy val arbRegistrationStatus: Arbitrary[RegistrationStatus]                                 = mkArb
+  implicit lazy val arbVerificationStatus: Arbitrary[VerificationStatus]                                 = mkArb
+  implicit lazy val arbEtmpSubscriptionStatus: Arbitrary[EtmpSubscriptionStatus]                         = mkArb
+  implicit lazy val arbIncorporatedEntityJourneyData: Arbitrary[IncorporatedEntityJourneyData]           = mkArb
+  implicit lazy val arbPartnershipEntityJourneyData: Arbitrary[PartnershipEntityJourneyData]             = mkArb
+  implicit lazy val arbSoleTraderEntityJourneyData: Arbitrary[SoleTraderEntityJourneyData]               = mkArb
+  implicit lazy val arbEclAddress: Arbitrary[EclAddress]                                                 = mkArb
+  implicit lazy val arbCreateEclSubscriptionResponse: Arbitrary[CreateEclSubscriptionResponse]           = mkArb
+  implicit lazy val arbEclSubscription: Arbitrary[EclSubscription]                                       = mkArb
+  implicit lazy val arbUpsertKnownFactsRequest: Arbitrary[UpsertKnownFactsRequest]                       = mkArb
+  implicit lazy val arbEitherErrorOrHttpResponse: Arbitrary[Either[UpstreamErrorResponse, HttpResponse]] = mkArb
+  implicit lazy val arbWorkItemKnownFactsWorkItem: Arbitrary[WorkItem[KnownFactsWorkItem]]               = mkArb
 
 }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EnrolmentStoreProxyConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EnrolmentStoreProxyConnectorSpec.scala
@@ -39,9 +39,7 @@ class EnrolmentStoreProxyConnectorSpec extends SpecBase {
         upsertKnownFactsRequest: UpsertKnownFactsRequest,
         eitherResult: Either[UpstreamErrorResponse, HttpResponse]
       ) =>
-        val enrolmentKey = s"${EclEnrolment.ServiceName}~${EclEnrolment.IdentifierKey}~$eclReference"
-
-        val expectedUrl = s"$enrolmentStoreUrl/enrolments/$enrolmentKey"
+        val expectedUrl = s"$enrolmentStoreUrl/enrolments/${EclEnrolment.EnrolmentKey(eclReference)}"
 
         when(
           mockHttpClient

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/services/KnownFactsQueuePullSchedulerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/services/KnownFactsQueuePullSchedulerSpec.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.services
+
+import akka.actor.ActorSystem
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
+import uk.gov.hmrc.economiccrimelevyregistration.connectors.EnrolmentStoreProxyConnector
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
+import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.{EclEnrolment, UpsertKnownFactsRequest}
+import uk.gov.hmrc.economiccrimelevyregistration.models.{KeyValue, KnownFactsWorkItem}
+import uk.gov.hmrc.economiccrimelevyregistration.repositories.KnownFactsQueueRepository
+import uk.gov.hmrc.http.{HttpResponse, UpstreamErrorResponse}
+import uk.gov.hmrc.mongo.workitem.{ProcessingStatus, WorkItem}
+
+import scala.concurrent.Future
+
+class KnownFactsQueuePullSchedulerSpec extends SpecBase {
+  val mockEnrolmentStoreProxyConnector: EnrolmentStoreProxyConnector = mock[EnrolmentStoreProxyConnector]
+  val mockKnownFactsQueueRepository: KnownFactsQueueRepository       = mock[KnownFactsQueueRepository]
+
+  val scheduler = new KnownFactsQueuePullScheduler(
+    ActorSystem.create(),
+    mockKnownFactsQueueRepository,
+    mockEnrolmentStoreProxyConnector
+  )
+
+  "processKnownFacts" should {
+    "if there is nothing to process, do nothing and return unit" in {
+      when(mockKnownFactsQueueRepository.pullOutstanding(any(), any())).thenReturn(Future.successful(None))
+
+      val result: Unit = await(scheduler.processKnownFacts)
+
+      result shouldBe ()
+    }
+
+    "if there is something to process, upsert the known fact and if successful, mark it as completed and delete from the queue" in forAll {
+      knownFactsWorkItem: WorkItem[KnownFactsWorkItem] =>
+        when(mockKnownFactsQueueRepository.pullOutstanding(any(), any()))
+          .thenReturn(Future.successful(Some(knownFactsWorkItem)))
+
+        val expectedUpsertKnownFactsRequest =
+          UpsertKnownFactsRequest(verifiers =
+            Seq(KeyValue(EclEnrolment.VerifierKey, knownFactsWorkItem.item.eclRegistrationDate))
+          )
+
+        when(
+          mockEnrolmentStoreProxyConnector.upsertKnownFacts(
+            ArgumentMatchers.eq(expectedUpsertKnownFactsRequest),
+            ArgumentMatchers.eq(knownFactsWorkItem.item.eclReference)
+          )(any())
+        ).thenReturn(Future.successful(Right(HttpResponse(OK, "", Map.empty))))
+
+        when(mockKnownFactsQueueRepository.completeAndDelete(ArgumentMatchers.eq(knownFactsWorkItem.id)))
+          .thenReturn(Future.successful(true))
+
+        val result: Unit = await(scheduler.processKnownFacts)
+
+        result shouldBe ()
+
+        verify(mockEnrolmentStoreProxyConnector, times(1))
+          .upsertKnownFacts(
+            ArgumentMatchers.eq(expectedUpsertKnownFactsRequest),
+            ArgumentMatchers.eq(knownFactsWorkItem.item.eclReference)
+          )(any())
+
+        verify(mockKnownFactsQueueRepository, times(1))
+          .completeAndDelete(ArgumentMatchers.eq(knownFactsWorkItem.id))
+
+        reset(mockEnrolmentStoreProxyConnector)
+        reset(mockKnownFactsQueueRepository)
+    }
+
+    "if there is something to process, upsert the known fact and if unsuccessful, mark it as failed" in forAll {
+      knownFactsWorkItem: WorkItem[KnownFactsWorkItem] =>
+        when(mockKnownFactsQueueRepository.pullOutstanding(any(), any()))
+          .thenReturn(Future.successful(Some(knownFactsWorkItem)))
+
+        val expectedUpsertKnownFactsRequest =
+          UpsertKnownFactsRequest(verifiers =
+            Seq(KeyValue(EclEnrolment.VerifierKey, knownFactsWorkItem.item.eclRegistrationDate))
+          )
+
+        when(
+          mockEnrolmentStoreProxyConnector.upsertKnownFacts(
+            ArgumentMatchers.eq(expectedUpsertKnownFactsRequest),
+            ArgumentMatchers.eq(knownFactsWorkItem.item.eclReference)
+          )(any())
+        ).thenReturn(
+          Future.successful(
+            Left(UpstreamErrorResponse("Internal server error", INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR))
+          )
+        )
+
+        when(
+          mockKnownFactsQueueRepository
+            .markAs(ArgumentMatchers.eq(knownFactsWorkItem.id), ArgumentMatchers.eq(ProcessingStatus.Failed), any())
+        )
+          .thenReturn(Future.successful(true))
+
+        val result: Unit = await(scheduler.processKnownFacts)
+
+        result shouldBe ()
+
+        verify(mockEnrolmentStoreProxyConnector, times(1))
+          .upsertKnownFacts(
+            ArgumentMatchers.eq(expectedUpsertKnownFactsRequest),
+            ArgumentMatchers.eq(knownFactsWorkItem.item.eclReference)
+          )(any())
+
+        verify(mockKnownFactsQueueRepository, times(1))
+          .markAs(ArgumentMatchers.eq(knownFactsWorkItem.id), ArgumentMatchers.eq(ProcessingStatus.Failed), any())
+
+        reset(mockEnrolmentStoreProxyConnector)
+        reset(mockKnownFactsQueueRepository)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/services/SubscriptionServiceSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/services/SubscriptionServiceSpec.scala
@@ -21,18 +21,28 @@ import org.mockito.ArgumentMatchers.any
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.{IntegrationFrameworkConnector, TaxEnrolmentsConnector}
 import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
+import uk.gov.hmrc.economiccrimelevyregistration.models.KnownFactsWorkItem
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.{CreateEclSubscriptionResponse, EclSubscription}
+import uk.gov.hmrc.economiccrimelevyregistration.repositories.KnownFactsQueueRepository
+import uk.gov.hmrc.http.{HttpResponse, UpstreamErrorResponse}
+import uk.gov.hmrc.mongo.workitem.WorkItem
 
+import java.time.Instant
 import scala.concurrent.Future
 
 class SubscriptionServiceSpec extends SpecBase {
   val mockIntegrationFrameworkConnector: IntegrationFrameworkConnector = mock[IntegrationFrameworkConnector]
   val mockTaxEnrolmentsConnector: TaxEnrolmentsConnector               = mock[TaxEnrolmentsConnector]
+  val mockKnownFactsQueueRepository: KnownFactsQueueRepository         = mock[KnownFactsQueueRepository]
 
-  val service = new SubscriptionService(mockIntegrationFrameworkConnector, mockTaxEnrolmentsConnector)
+  val service = new SubscriptionService(
+    mockIntegrationFrameworkConnector,
+    mockTaxEnrolmentsConnector,
+    mockKnownFactsQueueRepository
+  )
 
   "subscribeToEcl" should {
-    "return the ECL reference number" in forAll {
+    "return the ECL reference number when the subscription and enrolment is successful" in forAll {
       (
         eclSubscription: EclSubscription,
         subscriptionResponse: CreateEclSubscriptionResponse
@@ -41,11 +51,46 @@ class SubscriptionServiceSpec extends SpecBase {
           .thenReturn(Future.successful(subscriptionResponse))
 
         when(mockTaxEnrolmentsConnector.enrol(any())(any()))
-          .thenReturn(Future.successful(()))
+          .thenReturn(Future.successful(Right(HttpResponse(OK, "", Map.empty))))
 
         val result = await(service.subscribeToEcl(eclSubscription))
 
         result shouldBe subscriptionResponse
+    }
+
+    "return the ECL reference number and push the known facts to a queue when the subscription is successful but the enrolment fails" in forAll {
+      (
+        eclSubscription: EclSubscription,
+        subscriptionResponse: CreateEclSubscriptionResponse,
+        workItem: WorkItem[KnownFactsWorkItem]
+      ) =>
+        val updatedSubscriptionResponse =
+          subscriptionResponse.copy(processingDate = Instant.parse("2007-12-25T10:15:30.00Z"))
+
+        when(mockIntegrationFrameworkConnector.subscribeToEcl(ArgumentMatchers.eq(eclSubscription))(any()))
+          .thenReturn(Future.successful(updatedSubscriptionResponse))
+
+        when(mockTaxEnrolmentsConnector.enrol(any())(any()))
+          .thenReturn(
+            Future.successful(
+              Left(UpstreamErrorResponse("Internal server error", INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR))
+            )
+          )
+
+        val expectedKnownFactsWorkItem =
+          KnownFactsWorkItem(eclReference = updatedSubscriptionResponse.eclReference, eclRegistrationDate = "20071225")
+
+        when(mockKnownFactsQueueRepository.pushNew(ArgumentMatchers.eq(expectedKnownFactsWorkItem), any(), any()))
+          .thenReturn(Future.successful(workItem.copy(item = expectedKnownFactsWorkItem)))
+
+        val result = await(service.subscribeToEcl(eclSubscription))
+
+        result shouldBe updatedSubscriptionResponse
+
+        verify(mockKnownFactsQueueRepository, times(1))
+          .pushNew(ArgumentMatchers.eq(expectedKnownFactsWorkItem), any(), any())
+
+        reset(mockKnownFactsQueueRepository)
     }
   }
 }


### PR DESCRIPTION
The purpose of this is to handle the technically possible case that the call to synchronously enrol an entity after registering fails.

- In this case, the known fact data will be pushed to a queue (work-item-repo) and periodically pulled until the data is successfully sent to the known facts API so that a user can claim their enrolment.
- In this scenario, the user would need to claim their enrolment by providing the ECL reference and registration date as part of the claim enrolment journey.
- Naturally, it is possible that pushing to the queue might also fail as this is a mongo DB write, however this is much less likely and more resilient than the API call to enrol. If the write to the queue does fail, it will be an extremely exceptional case and the user would see a technical difficulties page, meaning a different process either involving ETMP or digital only would need to take place to get the right data into EACD.