### PR TITLE
Hardcode liabilityStartDate to 1st April 2022

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/integrationframework/EclSubscription.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/integrationframework/EclSubscription.scala
@@ -57,6 +57,8 @@ object LegalEntityDetails {
     val Organisation = "02"
   }
 
+  val StartOfFirstEclFinancialYear = "2022-04-01"
+
   implicit val format: OFormat[LegalEntityDetails] = Json.format[LegalEntityDetails]
 }
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
@@ -146,8 +146,7 @@ class RegistrationValidationService @Inject() (clock: Clock, schemaValidator: Sc
     def registrationDate: String =
       DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneOffset.UTC).format(Instant.now(clock))
 
-    def liabilityStartDate: String =
-      DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneOffset.UTC).format(Instant.now(clock))
+    def liabilityStartDate: String = "2022-04-01"
 
     registration.entityType match {
       case Some(UkLimitedCompany)                                                              =>

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models._
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationError
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationError._
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{IncorporatedEntityJourneyData, PartnershipEntityJourneyData, SoleTraderEntityJourneyData}
-import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.LegalEntityDetails.CustomerType
+import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.LegalEntityDetails.{CustomerType, StartOfFirstEclFinancialYear}
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework._
 import uk.gov.hmrc.economiccrimelevyregistration.utils.{SchemaLoader, SchemaValidator}
 
@@ -146,8 +146,6 @@ class RegistrationValidationService @Inject() (clock: Clock, schemaValidator: Sc
     def registrationDate: String =
       DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneOffset.UTC).format(Instant.now(clock))
 
-    def liabilityStartDate: String = "2022-04-01"
-
     registration.entityType match {
       case Some(UkLimitedCompany)                                                              =>
         grsJourneyData match {
@@ -161,7 +159,7 @@ class RegistrationValidationService @Inject() (clock: Clock, schemaValidator: Sc
                 lastName = None,
                 customerType = CustomerType.Organisation,
                 registrationDate = registrationDate,
-                liabilityStartDate = liabilityStartDate,
+                liabilityStartDate = StartOfFirstEclFinancialYear,
                 _,
                 _
               )
@@ -183,7 +181,7 @@ class RegistrationValidationService @Inject() (clock: Clock, schemaValidator: Sc
                 lastName = None,
                 customerType = CustomerType.Organisation,
                 registrationDate = registrationDate,
-                liabilityStartDate = liabilityStartDate,
+                liabilityStartDate = StartOfFirstEclFinancialYear,
                 _,
                 _
               )
@@ -206,7 +204,7 @@ class RegistrationValidationService @Inject() (clock: Clock, schemaValidator: Sc
                 lastName = None,
                 customerType = CustomerType.Organisation,
                 registrationDate = registrationDate,
-                liabilityStartDate = liabilityStartDate,
+                liabilityStartDate = StartOfFirstEclFinancialYear,
                 _,
                 _
               )
@@ -225,7 +223,7 @@ class RegistrationValidationService @Inject() (clock: Clock, schemaValidator: Sc
                 lastName = Some(s.fullName.lastName),
                 customerType = CustomerType.Individual,
                 registrationDate = registrationDate,
-                liabilityStartDate = liabilityStartDate,
+                liabilityStartDate = StartOfFirstEclFinancialYear,
                 _,
                 _
               )

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmissionISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmissionISpec.scala
@@ -11,6 +11,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models.KeyValue
 import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.{CreateEnrolmentRequest, EclEnrolment}
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.CreateEclSubscriptionResponse
+import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.LegalEntityDetails.StartOfFirstEclFinancialYear
 import uk.gov.hmrc.economiccrimelevyregistration.models.nrs._
 
 import java.time.format.DateTimeFormatter
@@ -26,13 +27,13 @@ class RegistrationSubmissionISpec extends ISpecBase {
         random[CreateEclSubscriptionResponse]
           .copy(processingDate = Instant.parse("2007-12-25T10:15:30.00Z"))
 
-      val registrationDate   = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
+      val registrationDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
 
       stubSubscribeToEcl(
         validRegistration.expectedEclSubscription.copy(subscription =
           validRegistration.expectedEclSubscription.subscription.copy(
             legalEntityDetails = validRegistration.expectedEclSubscription.subscription.legalEntityDetails
-              .copy(registrationDate = registrationDate, liabilityStartDate = "2022-04-01")
+              .copy(registrationDate = registrationDate, liabilityStartDate = StartOfFirstEclFinancialYear)
           )
         ),
         subscriptionResponse
@@ -79,13 +80,13 @@ class RegistrationSubmissionISpec extends ISpecBase {
         random[CreateEclSubscriptionResponse]
           .copy(processingDate = Instant.parse("2007-12-25T10:15:30.00Z"))
 
-      val registrationDate   = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
+      val registrationDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
 
       stubSubscribeToEcl(
         validRegistration.expectedEclSubscription.copy(subscription =
           validRegistration.expectedEclSubscription.subscription.copy(
             legalEntityDetails = validRegistration.expectedEclSubscription.subscription.legalEntityDetails
-              .copy(registrationDate = registrationDate, liabilityStartDate = "2022-04-01")
+              .copy(registrationDate = registrationDate, liabilityStartDate = StartOfFirstEclFinancialYear)
           )
         ),
         subscriptionResponse

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmissionISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmissionISpec.scala
@@ -23,13 +23,12 @@ class RegistrationSubmissionISpec extends ISpecBase {
         random[CreateEclSubscriptionResponse].copy(processingDate = Instant.parse("2007-12-25T10:15:30.00Z"))
 
       val registrationDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
-      val liabilityStartDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
 
       stubSubscribeToEcl(
         validRegistration.expectedEclSubscription.copy(subscription =
           validRegistration.expectedEclSubscription.subscription.copy(
             legalEntityDetails = validRegistration.expectedEclSubscription.subscription.legalEntityDetails
-              .copy(registrationDate = registrationDate, liabilityStartDate = liabilityStartDate)
+              .copy(registrationDate = registrationDate, liabilityStartDate = "2022-04-01")
           )
         ),
         subscriptionResponse

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmissionISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmissionISpec.scala
@@ -27,13 +27,12 @@ class RegistrationSubmissionISpec extends ISpecBase {
           .copy(processingDate = Instant.parse("2007-12-25T10:15:30.00Z"))
 
       val registrationDate   = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
-      val liabilityStartDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
 
       stubSubscribeToEcl(
         validRegistration.expectedEclSubscription.copy(subscription =
           validRegistration.expectedEclSubscription.subscription.copy(
             legalEntityDetails = validRegistration.expectedEclSubscription.subscription.legalEntityDetails
-              .copy(registrationDate = registrationDate, liabilityStartDate = liabilityStartDate)
+              .copy(registrationDate = registrationDate, liabilityStartDate = "2022-04-01")
           )
         ),
         subscriptionResponse

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
@@ -21,8 +21,8 @@ import org.bson.types.ObjectId
 import org.scalacheck.Gen.{choose, listOfN}
 import org.scalacheck.derive.MkArbitrary
 import org.scalacheck.{Arbitrary, Gen}
-import play.api.http.{HeaderNames, MimeTypes}
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK}
+import play.api.http.{HeaderNames, MimeTypes}
 import play.api.libs.json.{JsObject, JsString}
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -36,7 +36,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs._
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.EtmpSubscriptionStatus._
-import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.LegalEntityDetails.CustomerType
+import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.LegalEntityDetails.{CustomerType, StartOfFirstEclFinancialYear}
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework._
 import uk.gov.hmrc.economiccrimelevyregistration.models.nrs._
 import uk.gov.hmrc.economiccrimelevyregistration.models.requests.AuthorisedRequest
@@ -238,7 +238,7 @@ trait EclTestData {
             lastName = None,
             customerType = CustomerType.Organisation,
             registrationDate = "2007-12-25",
-            liabilityStartDate = "2022-04-01",
+            liabilityStartDate = StartOfFirstEclFinancialYear,
             amlSupervisor = "Hmrc",
             businessSector = commonRegistrationData.registration.businessSector.get.toString
           ),
@@ -287,7 +287,7 @@ trait EclTestData {
             lastName = Some(soleTraderEntityJourneyData.fullName.lastName),
             customerType = CustomerType.Individual,
             registrationDate = "2007-12-25",
-            liabilityStartDate = "2022-04-01",
+            liabilityStartDate = StartOfFirstEclFinancialYear,
             amlSupervisor = "Hmrc",
             businessSector = commonRegistrationData.registration.businessSector.get.toString
           ),
@@ -337,7 +337,7 @@ trait EclTestData {
             lastName = None,
             customerType = CustomerType.Organisation,
             registrationDate = "2007-12-25",
-            liabilityStartDate = "2022-04-01",
+            liabilityStartDate = StartOfFirstEclFinancialYear,
             amlSupervisor = "Hmrc",
             businessSector = commonRegistrationData.registration.businessSector.get.toString
           ),
@@ -391,7 +391,7 @@ trait EclTestData {
               lastName = None,
               customerType = CustomerType.Organisation,
               registrationDate = "2007-12-25",
-              liabilityStartDate = "2022-04-01",
+              liabilityStartDate = StartOfFirstEclFinancialYear,
               amlSupervisor = "Hmrc",
               businessSector = commonRegistrationData.registration.businessSector.get.toString
             ),

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
@@ -209,7 +209,7 @@ trait EclTestData {
             lastName = None,
             customerType = CustomerType.Organisation,
             registrationDate = "2007-12-25",
-            liabilityStartDate = "2007-12-25",
+            liabilityStartDate = "2022-04-01",
             amlSupervisor = "Hmrc",
             businessSector = commonRegistrationData.registration.businessSector.get.toString
           ),
@@ -258,7 +258,7 @@ trait EclTestData {
             lastName = Some(soleTraderEntityJourneyData.fullName.lastName),
             customerType = CustomerType.Individual,
             registrationDate = "2007-12-25",
-            liabilityStartDate = "2007-12-25",
+            liabilityStartDate = "2022-04-01",
             amlSupervisor = "Hmrc",
             businessSector = commonRegistrationData.registration.businessSector.get.toString
           ),
@@ -308,7 +308,7 @@ trait EclTestData {
             lastName = None,
             customerType = CustomerType.Organisation,
             registrationDate = "2007-12-25",
-            liabilityStartDate = "2007-12-25",
+            liabilityStartDate = "2022-04-01",
             amlSupervisor = "Hmrc",
             businessSector = commonRegistrationData.registration.businessSector.get.toString
           ),
@@ -362,7 +362,7 @@ trait EclTestData {
               lastName = None,
               customerType = CustomerType.Organisation,
               registrationDate = "2007-12-25",
-              liabilityStartDate = "2007-12-25",
+              liabilityStartDate = "2022-04-01",
               amlSupervisor = "Hmrc",
               businessSector = commonRegistrationData.registration.businessSector.get.toString
             ),


### PR DESCRIPTION
This is needed so that before October 1st 2023 the correct obligation for the 2022/2023 tax year is generated in ETMP.