### PR TITLE
Specify a different bearer token for the Get Subscription Status API

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/config/AppConfig.scala
@@ -36,6 +36,9 @@ class AppConfig @Inject() (configuration: Configuration, servicesConfig: Service
   val integrationFrameworkBearerToken: String =
     configuration.get[String]("microservice.services.integration-framework.bearerToken")
 
+  val getSubscriptionStatusBearerToken: String =
+    configuration.get[String]("microservice.services.integration-framework.getSubscriptionStatusBearerToken")
+
   val integrationFrameworkEnvironment: String =
     configuration.get[String]("microservice.services.integration-framework.environment")
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/IntegrationFrameworkConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/IntegrationFrameworkConnector.scala
@@ -34,8 +34,8 @@ class IntegrationFrameworkConnector @Inject() (
   correlationIdGenerator: CorrelationIdGenerator
 )(implicit ec: ExecutionContext) {
 
-  private def integrationFrameworkHeaders: Seq[(String, String)] = Seq(
-    (HeaderNames.AUTHORIZATION, s"Bearer ${appConfig.integrationFrameworkBearerToken}"),
+  private def integrationFrameworkHeaders(bearerToken: String): Seq[(String, String)] = Seq(
+    (HeaderNames.AUTHORIZATION, s"Bearer $bearerToken"),
     (CustomHeaderNames.Environment, appConfig.integrationFrameworkEnvironment),
     (CustomHeaderNames.CorrelationId, correlationIdGenerator.generateCorrelationId)
   )
@@ -45,7 +45,7 @@ class IntegrationFrameworkConnector @Inject() (
   )(implicit hc: HeaderCarrier): Future[SubscriptionStatusResponse] =
     httpClient.GET[SubscriptionStatusResponse](
       s"${appConfig.integrationFrameworkUrl}/cross-regime/subscription/ECL/SAFE/$businessPartnerId/status",
-      headers = integrationFrameworkHeaders
+      headers = integrationFrameworkHeaders(appConfig.integrationFrameworkBearerToken)
     )
 
   def subscribeToEcl(eclSubscription: EclSubscription)(implicit
@@ -54,7 +54,7 @@ class IntegrationFrameworkConnector @Inject() (
     httpClient.POST[Subscription, Either[UpstreamErrorResponse, CreateEclSubscriptionResponse]](
       s"${appConfig.integrationFrameworkUrl}/economic-crime-levy/subscription/${eclSubscription.businessPartnerId}",
       eclSubscription.subscription,
-      headers = integrationFrameworkHeaders
+      headers = integrationFrameworkHeaders(appConfig.getSubscriptionStatusBearerToken)
     )
 
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/IntegrationFrameworkConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/IntegrationFrameworkConnector.scala
@@ -45,7 +45,7 @@ class IntegrationFrameworkConnector @Inject() (
   )(implicit hc: HeaderCarrier): Future[SubscriptionStatusResponse] =
     httpClient.GET[SubscriptionStatusResponse](
       s"${appConfig.integrationFrameworkUrl}/cross-regime/subscription/ECL/SAFE/$businessPartnerId/status",
-      headers = integrationFrameworkHeaders(appConfig.integrationFrameworkBearerToken)
+      headers = integrationFrameworkHeaders(appConfig.getSubscriptionStatusBearerToken)
     )
 
   def subscribeToEcl(eclSubscription: EclSubscription)(implicit
@@ -54,7 +54,7 @@ class IntegrationFrameworkConnector @Inject() (
     httpClient.POST[Subscription, Either[UpstreamErrorResponse, CreateEclSubscriptionResponse]](
       s"${appConfig.integrationFrameworkUrl}/economic-crime-levy/subscription/${eclSubscription.businessPartnerId}",
       eclSubscription.subscription,
-      headers = integrationFrameworkHeaders(appConfig.getSubscriptionStatusBearerToken)
+      headers = integrationFrameworkHeaders(appConfig.integrationFrameworkBearerToken)
     )
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -128,6 +128,7 @@ microservice {
       host = localhost
       port = 14004
       bearerToken = test
+      getSubscriptionStatusBearerToken = test
       environment = test
     }
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/IntegrationFrameworkConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/IntegrationFrameworkConnectorSpec.scala
@@ -44,7 +44,7 @@ class IntegrationFrameworkConnectorSpec extends SpecBase {
           s"${appConfig.integrationFrameworkUrl}/cross-regime/subscription/ECL/SAFE/$businessPartnerId/status"
 
         val expectedHeaders: Seq[(String, String)] = Seq(
-          (HeaderNames.AUTHORIZATION, s"Bearer ${appConfig.integrationFrameworkBearerToken}"),
+          (HeaderNames.AUTHORIZATION, s"Bearer ${appConfig.getSubscriptionStatusBearerToken}"),
           (CustomHeaderNames.Environment, appConfig.integrationFrameworkEnvironment),
           (CustomHeaderNames.CorrelationId, correlationId)
         )


### PR DESCRIPTION
This is because EIS have informed us that the Get Subscription Status API requires a separate bearer token due to the fact it's hosted as part of the plastic packaging tax service infrastructure, therefore we can't share the token with other ECL specific subscription APIs. There is a wider discussion about this as an element of tech debt for EIS to address going forward.