### PR TITLE
Simplify the handling of ETMP subscription status

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/integrationframework/SubscriptionStatusResponse.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/integrationframework/SubscriptionStatusResponse.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework
 import play.api.libs.json._
 import uk.gov.hmrc.economiccrimelevyregistration.models.EclSubscriptionStatus
 import uk.gov.hmrc.economiccrimelevyregistration.models.EclSubscriptionStatus._
-import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.EtmpSubscriptionStatus._
 
 sealed trait EtmpSubscriptionStatus
 
@@ -97,15 +96,9 @@ final case class SubscriptionStatusResponse(
       idType,
       idValue
     ) match {
-      case (Successful, Some("ZECL"), Some(eclRegistrationReference))                           =>
+      case (_, Some("ZECL"), Some(eclRegistrationReference)) =>
         EclSubscriptionStatus(Subscribed(eclRegistrationReference))
-      case (Successful, None, None) | (Successful, Some(_), None) | (Successful, None, Some(_)) =>
-        throw new IllegalStateException("Subscription status is Successful but there is no id type or value")
-      case (subscriptionStatus, Some(idType), Some(idValue))                                    =>
-        throw new IllegalStateException(
-          s"Subscription status $subscriptionStatus returned with unexpected idType $idType and value $idValue"
-        )
-      case _                                                                                    => EclSubscriptionStatus(NotSubscribed)
+      case _                                                 => EclSubscriptionStatus(NotSubscribed)
     }
 }
 

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
@@ -35,7 +35,6 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.AmlSupervisorType.Hmrc
 import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs._
-import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.EtmpSubscriptionStatus._
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.LegalEntityDetails.{CustomerType, StartOfFirstEclFinancialYear}
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework._
 import uk.gov.hmrc.economiccrimelevyregistration.models.nrs._
@@ -100,21 +99,6 @@ trait EclTestData {
       registration <- MkArbitrary[Registration].arbitrary.arbitrary
       internalId   <- Gen.nonEmptyListOf(Arbitrary.arbitrary[Char]).map(_.mkString)
     } yield registration.copy(internalId = internalId)
-  }
-
-  implicit val arbSubscriptionStatusResponse: Arbitrary[SubscriptionStatusResponse] = Arbitrary {
-    for {
-      etmpSubscriptionStatus   <- Arbitrary.arbitrary[EtmpSubscriptionStatus]
-      idType                    = if (etmpSubscriptionStatus == Successful) Some("ZECL") else None
-      eclRegistrationReference <- Arbitrary.arbitrary[String]
-      idValue                   = if (etmpSubscriptionStatus == Successful) Some(eclRegistrationReference) else None
-      channel                  <- Arbitrary.arbitrary[Option[Channel]]
-    } yield SubscriptionStatusResponse(
-      etmpSubscriptionStatus,
-      idType,
-      idValue,
-      channel
-    )
   }
 
   def alphaNumStringsWithMaxLength(maxLength: Int): Gen[String] =

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
@@ -55,5 +55,6 @@ object CachedArbitraries extends EclTestData {
   implicit lazy val arbNrsIdentityData: Arbitrary[NrsIdentityData]                                       = mkArb
   implicit lazy val arbNrsSubmission: Arbitrary[NrsSubmission]                                           = mkArb
   implicit lazy val arbNrsSubmissionResponse: Arbitrary[NrsSubmissionResponse]                           = mkArb
+  implicit lazy val arbSubcriptionStatusResponse: Arbitrary[SubscriptionStatusResponse]                  = mkArb
 
 }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/SubscriptionStatusControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/SubscriptionStatusControllerSpec.scala
@@ -22,6 +22,7 @@ import play.api.libs.json.Json
 import play.api.mvc.Result
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.IntegrationFrameworkConnector
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.SubscriptionStatusResponse
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 


### PR DESCRIPTION
Simplified so that:

- If there is an ECL reference with the subscription status, they are subscribed
- If there is no ECL reference, they are not subscribed