### PR TITLE
ECL-335: Code Tweaks

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/config/AppConfig.scala
@@ -67,7 +67,7 @@ class AppConfig @Inject() (configuration: Configuration, servicesConfig: Service
   val dmsSubmissionBusinessArea: String       =
     configuration.get[String]("microservice.services.dms-submission.registration-submission.businessArea")
   val dmsSubmissionCallbackEndpoint: String   =
-    appBaseUrl + configuration.get[String](
+    configuration.get[String](
       "microservice.services.dms-submission.registration-submission.callbackEndpoint"
     )
   val dmsSubmissionCallbackUrl: String        = s"$appBaseUrl/$appName/$dmsSubmissionCallbackEndpoint"

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/config/InternalAuthTokenInitialiser.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/config/InternalAuthTokenInitialiser.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.economiccrimelevyregistration.config
 
 import play.api.Logging
-import play.api.http.Status.{ACCEPTED, CREATED}
+import play.api.http.Status.{CREATED, NO_CONTENT}
 import play.api.libs.json.Json
 import uk.gov.hmrc.economiccrimelevyregistration.models.Done
 import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
@@ -45,8 +45,16 @@ class InternalAuthTokenInitialiserImpl @Inject() (
     extends InternalAuthTokenInitialiser
     with Logging {
 
-  override val initialised: Future[Done] =
-    ensureAuthToken()
+  override val initialised: Future[Done] = {
+    val authToken = ensureAuthToken()
+    val resources = ensureResourceDefinitions()
+    val grants    = ensureGrants()
+    val seq       = Seq(authToken, resources, grants)
+
+    Future
+      .sequence(seq)
+      .map(_ => Done)
+  }
 
   Await.result(initialised, 30.seconds)
 
@@ -65,42 +73,26 @@ class InternalAuthTokenInitialiserImpl @Inject() (
     httpClient
       .post(url"${appConfig.internalAuthBaseUrl}/test-only/token")(HeaderCarrier())
       .withBody(
-        Json.obj(
-          "token"       -> appConfig.internalAuthToken,
-          "principal"   -> appConfig.appName,
-          "permissions" -> Seq(
-            Json.obj(
-              "resourceType"     -> "dms-submission",
-              "resourceLocation" -> "submit",
-              "actions"          -> List("WRITE")
-            )
-          )
-        )
+        Json.parse(
+          s"""
+             |{
+             | "token": "${appConfig.internalAuthToken}",
+             | "principal": "${appConfig.appName}",
+             | "permissions": [
+             |   {
+             |    "resourceType": "dms-submission",
+             |    "resourceLocation": "submit",
+             |    "actions": ["WRITE"]
+             |   }
+             | ]
+             |}
+          |""".stripMargin)
       )
       .execute
       .flatMap { response =>
         if (response.status == CREATED) {
           logger.info("Auth token initialised")
-          httpClient
-            .post(url"${appConfig.internalAuthBaseUrl}/test-only/token")(HeaderCarrier())
-            .withBody(
-              Json.obj(
-                "token"       -> "71930935-381b-4e0c-bdcf-b51fc18b7589",
-                "principal"   -> "dms-submission",
-                "permissions" -> Seq(
-                  Json.obj(
-                    "resourceType"     -> appConfig.appName,
-                    "resourceLocation" -> "dms-registration-callback",
-                    "actions"          -> List("WRITE")
-                  )
-                )
-              )
-            )
-            .execute.map { r => r.status match {
-              case CREATED => Done
-              case _ => throw new RuntimeException("Unable to initialise internal-auth token")
-            }
-          }
+          Future.successful(Done)
         } else {
           Future.failed(new RuntimeException("Unable to initialise internal-auth token"))
         }
@@ -115,5 +107,118 @@ class InternalAuthTokenInitialiserImpl @Inject() (
       .setHeader("Authorization" -> appConfig.internalAuthToken)
       .execute
       .map(_.status == 200)
+  }
+
+  private def ensureGrants(): Future[Done] = {
+    logger.info("Creating grants")
+    httpClient
+      .put(url"${appConfig.internalAuthBaseUrl}/test-only/grants")(HeaderCarrier())
+      .withBody(
+        Json.parse(
+          s"""
+             |[
+             |  {
+             |    "grantees": [
+             |      {
+             |        "granteeType": "user",
+             |        "identifier": "dms-submission"
+             |      }
+             |    ],
+             |    "permissions": [
+             |      {
+             |        "resourceType": "object-store",
+             |        "resourceLocation": "dms-submission",
+             |        "actions": [
+             |          "READ",
+             |          "WRITE",
+             |          "DELETE"
+             |        ]
+             |      }
+             |    ]
+             |  },
+             |  {
+             |    "grantees": [
+             |      {
+             |        "granteeType": "user",
+             |        "identifier": "economic-crime-levy-registration"
+             |      }
+             |    ],
+             |    "permissions": [
+             |      {
+             |        "resourceType": "dms-submission",
+             |        "resourceLocation": "submit",
+             |        "actions": [
+             |          "WRITE"
+             |        ]
+             |      }
+             |    ]
+             |  },
+             |  {
+             |    "grantees": [
+             |      {
+             |        "granteeType": "user",
+             |        "identifier": "dms-submission"
+             |      }
+             |    ],
+             |    "permissions": [
+             |      {
+             |        "resourceType": "economic-crime-levy-registration",
+             |        "resourceLocation": "dms-registration-callback",
+             |        "actions": [
+             |          "WRITE"
+             |        ]
+             |      }
+             |    ]
+             |  }
+             |]
+             |""".stripMargin
+        )
+      )
+      .execute
+      .flatMap { response =>
+        if (response.status == NO_CONTENT) {
+          logger.info("Grants created")
+          Future.successful(Done)
+        } else {
+          Future.failed(new RuntimeException("Unable to create grants"))
+        }
+      }
+  }
+
+  private def ensureResourceDefinitions(): Future[Done] = {
+    logger.info("Creating resource definitions")
+    httpClient
+      .put(url"${appConfig.internalAuthBaseUrl}/test-only/resource-definitions")(HeaderCarrier())
+      .withBody(
+        Json.parse(
+          s"""
+             |[
+             |  {
+             |    "resourceType": "dms-submission",
+             |    "actions": [
+             |      "READ",
+             |      "WRITE",
+             |      "DELETE"
+             |    ]
+             |  },
+             |  {
+             |    "resourceType": "economic-crime-levy-registration",
+             |    "actions": [
+             |      "WRITE"
+             |    ]
+             |  }
+             |]
+             |""".stripMargin
+        )
+      )
+      .execute
+      .flatMap { response =>
+        if (response.status == NO_CONTENT) {
+          logger.info("Resource definitions created")
+          Future.successful(Done)
+        } else {
+          Future.failed(new RuntimeException("Unable to create resource definitions"))
+        }
+      }
   }
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/config/InternalAuthTokenInitialiser.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/config/InternalAuthTokenInitialiser.scala
@@ -73,8 +73,7 @@ class InternalAuthTokenInitialiserImpl @Inject() (
     httpClient
       .post(url"${appConfig.internalAuthBaseUrl}/test-only/token")(HeaderCarrier())
       .withBody(
-        Json.parse(
-          s"""
+        Json.parse(s"""
              |{
              | "token": "${appConfig.internalAuthToken}",
              | "principal": "${appConfig.appName}",

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/config/InternalAuthTokenInitialiser.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/config/InternalAuthTokenInitialiser.scala
@@ -85,12 +85,12 @@ class InternalAuthTokenInitialiserImpl @Inject() (
             .post(url"${appConfig.internalAuthBaseUrl}/test-only/token")(HeaderCarrier())
             .withBody(
               Json.obj(
-                "token"       -> "dms-submission",
-                "principal"   -> appConfig.internalAuthToken,
+                "token"       -> "71930935-381b-4e0c-bdcf-b51fc18b7589",
+                "principal"   -> "dms-submission",
                 "permissions" -> Seq(
                   Json.obj(
                     "resourceType"     -> appConfig.appName,
-                    "resourceLocation" -> "submit",
+                    "resourceLocation" -> "dms-registration-callback",
                     "actions"          -> List("WRITE")
                   )
                 )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/DmsConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/DmsConnector.scala
@@ -17,85 +17,50 @@
 package uk.gov.hmrc.economiccrimelevyregistration.connectors
 
 import akka.NotUsed
+import akka.actor.ActorSystem
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import com.typesafe.config.Config
 import play.api.Logging
 import play.api.http.HeaderNames.AUTHORIZATION
-import play.api.http.HttpEntity
-import play.api.http.Status.{ACCEPTED, INTERNAL_SERVER_ERROR}
-import play.api.libs.ws.BodyWritable
-import play.api.mvc.MultipartFormData.{DataPart, FilePart}
-import play.api.mvc.{MultipartFormData, ResponseHeader, Result}
+import play.api.mvc.MultipartFormData
 import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
-import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, Retries, UpstreamErrorResponse}
 
-import java.io.ByteArrayOutputStream
 import java.net.URL
-import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
-import java.time.{Instant, LocalDateTime, ZoneOffset}
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class DmsConnector @Inject() (
   httpClient: HttpClientV2,
-  appConfig: AppConfig
+  appConfig: AppConfig,
+  override val configuration: Config,
+  override val actorSystem: ActorSystem
 )(implicit ec: ExecutionContext)
-    extends Logging {
+    extends Retries
+    with Logging {
+
+  private def retryCondition: PartialFunction[Exception, Boolean] = {
+    case e: UpstreamErrorResponse if UpstreamErrorResponse.Upstream5xxResponse.unapply(e).isDefined => true
+  }
 
   def sendPdf(
     body: Source[MultipartFormData.Part[Source[ByteString, NotUsed]] with Product with Serializable, NotUsed]
-  )(implicit hc: HeaderCarrier): Future[Boolean] =
-    isOk(
-      post(
-        appConfig.retryDuration.toList,
-        httpClient
-          .post(new URL(appConfig.dmsSubmissionUrl))
-          .setHeader(AUTHORIZATION -> appConfig.internalAuthToken)
-          .withBody(body)
-      )
-    )
-
-  private def post(retries: List[Duration], request: RequestBuilder)(implicit
-    hc: HeaderCarrier
-  ): Future[Result] =
-    if (retries.isEmpty) {
-      Future.successful(result(INTERNAL_SERVER_ERROR))
-    } else {
-      request.execute.map { r =>
-        log(r)
-        r.status match {
-          case INTERNAL_SERVER_ERROR =>
-            val timeout = retries.head
-            Thread.sleep(timeout.toMillis)
-            Await.result(post(retries.tail, request), timeout)
-          case _                     =>
-            result(r.status)
+  )(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, Unit]] =
+    retryFor[Either[UpstreamErrorResponse, Unit]]("DMS submission")(retryCondition) {
+      httpClient
+        .post(new URL(appConfig.dmsSubmissionUrl))
+        .setHeader(AUTHORIZATION -> appConfig.internalAuthToken)
+        .withBody(body)
+        .execute[Either[UpstreamErrorResponse, HttpResponse]]
+        .map {
+          case Right(_)                                   => Right(())
+          case Left(errorResponse: UpstreamErrorResponse) => throw errorResponse
         }
-      }
+    }.recoverWith { case errorResponse: UpstreamErrorResponse =>
+      Future.successful(Left(errorResponse))
     }
-
-  private def log(response: HttpResponse) = {
-    val message = s"status = ${response.status}, body = ${response.body}"
-    isOk(response.status) match {
-      case true  => logger.info(message)
-      case false => logger.error(message)
-    }
-  }
-
-  private def result(status: Int): Result =
-    Result(
-      ResponseHeader(status, Map.empty),
-      HttpEntity.NoEntity
-    )
-
-  private def isOk(result: Future[Result]): Future[Boolean] =
-    result.map(r => isOk(r.header.status))
-
-  private def isOk(status: Int): Boolean =
-    status == ACCEPTED
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/DmsConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/DmsConnector.scala
@@ -49,15 +49,15 @@ class DmsConnector @Inject() (
 
   def sendPdf(
     body: Source[MultipartFormData.Part[Source[ByteString, NotUsed]] with Product with Serializable, NotUsed]
-  )(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, Unit]] =
-    retryFor[Either[UpstreamErrorResponse, Unit]]("DMS submission")(retryCondition) {
+  )(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, HttpResponse]] =
+    retryFor[Either[UpstreamErrorResponse, HttpResponse]]("DMS submission")(retryCondition) {
       httpClient
         .post(new URL(appConfig.dmsSubmissionUrl))
         .setHeader(AUTHORIZATION -> appConfig.internalAuthToken)
         .withBody(body)
         .execute[Either[UpstreamErrorResponse, HttpResponse]]
         .map {
-          case Right(_)                                   => Right(())
+          case Right(httpResponse: HttpResponse)          => Right(httpResponse)
           case Left(errorResponse: UpstreamErrorResponse) => throw errorResponse
         }
     }.recoverWith { case errorResponse: UpstreamErrorResponse =>

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/DmsNotificationController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/DmsNotificationController.scala
@@ -37,7 +37,7 @@ class DmsNotificationController @Inject() (
   private val predicate = Predicate.Permission(
     resource = Resource(
       resourceType = ResourceType(appConfig.appName),
-      resourceLocation = ResourceLocation(routes.DmsNotificationController.dmsCallback().url)
+      resourceLocation = ResourceLocation("submit")
     ),
     action = IAAction("WRITE")
   )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/DmsNotificationController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/DmsNotificationController.scala
@@ -37,7 +37,7 @@ class DmsNotificationController @Inject() (
   private val predicate = Predicate.Permission(
     resource = Resource(
       resourceType = ResourceType(appConfig.appName),
-      resourceLocation = ResourceLocation("submit")
+      resourceLocation = ResourceLocation("dms-registration-callback")
     ),
     action = IAAction("WRITE")
   )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmissionController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmissionController.scala
@@ -25,9 +25,9 @@ import uk.gov.hmrc.economiccrimelevyregistration.repositories.RegistrationReposi
 import uk.gov.hmrc.economiccrimelevyregistration.services.{DmsService, NrsService, RegistrationValidationService, SubscriptionService}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
+import java.time.Instant
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
-import java.time.Instant
 
 @Singleton
 class RegistrationSubmissionController @Inject() (
@@ -51,13 +51,13 @@ class RegistrationSubmissionController @Inject() (
                 registration.base64EncodedNrsSubmissionHtml,
                 response.success.eclReference
               )
-
               Ok(Json.toJson(response.success))
             }
           case Valid(Right(registration))   =>
             val now = Instant.now
-            dmsService.submitToDms(registration.base64EncodedDmsSubmissionHtml, now).map { response =>
-              Ok(Json.toJson(response))
+            dmsService.submitToDms(registration.base64EncodedDmsSubmissionHtml, now).map {
+              case Right(response) => Ok(Json.toJson(response))
+              case Left(_)         => InternalServerError("Could not send PDF to DMS queue")
             }
           case Invalid(e)                   =>
             Future.successful(InternalServerError(Json.toJson(DataValidationErrors(e.toList))))
@@ -65,5 +65,4 @@ class RegistrationSubmissionController @Inject() (
       case None               => Future.successful(NotFound)
     }
   }
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,8 @@ val excludedScoveragePackages: Seq[String] = Seq(
   "prod.*",
   ".*Routes.*",
   ".*testonly.*",
-  "testOnlyDoNotUseInAppConf.*"
+  "testOnlyDoNotUseInAppConf.*",
+  ".*config.*"
 )
 
 val scoverageSettings: Seq[Setting[_]] = Seq(

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmissionISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmissionISpec.scala
@@ -157,12 +157,12 @@ class RegistrationSubmissionISpec extends ISpecBase {
       verify(1, postRequestedFor(urlEqualTo("/dms-submission/submit")))
     }
 
-    "return INTERNAL_SERVER_ERROR if call to DMS fails 3 times" in {
+    "return INTERNAL_SERVER_ERROR if call to DMS fails after three retries" in {
       stubAuthorised()
 
       val html = "<html><head></head><body></body></html>"
-      val charityRegistration  = random[ValidCharityRegistration]
-      val validRegistration    = charityRegistration.copy(
+      val charityRegistration = random[ValidCharityRegistration]
+      val validRegistration = charityRegistration.copy(
         registration = charityRegistration.registration.copy(
           base64EncodedDmsSubmissionHtml = Some(Base64.getEncoder.encodeToString(html.getBytes))
         )
@@ -184,9 +184,8 @@ class RegistrationSubmissionISpec extends ISpecBase {
         )
       )
 
-      status(result)        shouldBe INTERNAL_SERVER_ERROR
-      verify(3, postRequestedFor(urlEqualTo("/dms-submission/submit")))
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+      verify(4, postRequestedFor(urlEqualTo("/dms-submission/submit")))
     }
   }
-
 }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/DmsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/DmsConnectorSpec.scala
@@ -16,60 +16,69 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.connectors
 
+import akka.actor.ActorSystem
 import akka.stream.scaladsl.Source
+import com.typesafe.config.Config
 import org.mockito.ArgumentMatchers.any
-import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
-import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.http.{HttpResponse, UpstreamErrorResponse}
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 
 import scala.concurrent.Future
 
 class DmsConnectorSpec extends SpecBase {
 
-  override def configOverrides(): Map[String, Any] = Map(
+  override def configOverrides: Map[String, Any] = Map(
     "http-verbs.retries.intervals" -> List("1ms")
   )
 
+  val actorSystem: ActorSystem           = ActorSystem("test")
+  val config: Config                     = app.injector.instanceOf[Config]
   val mockRequestBuilder: RequestBuilder = mock[RequestBuilder]
   val mockHttpClient: HttpClientV2       = mock[HttpClientV2]
   val connector                          = new DmsConnector(
     mockHttpClient,
-    appConfig
+    appConfig,
+    config,
+    actorSystem
   )
 
   "sendPdf" should {
-    "return true if post to DMS queue succeeds" in {
-      test(ACCEPTED, true)
+    "return Unit if post to DMS queue succeeds" in {
+      when(mockHttpClient.post(any())(any())).thenReturn(mockRequestBuilder)
+      when(mockRequestBuilder.setHeader(any())).thenReturn(mockRequestBuilder)
+      when(mockRequestBuilder.withBody(any())(any(), any(), any())).thenReturn(mockRequestBuilder)
+      when(mockRequestBuilder.execute[Either[UpstreamErrorResponse, HttpResponse]](any(), any()))
+        .thenReturn(Future.successful(Right(HttpResponse.apply(OK, ""))))
+
+      val result = await(connector.sendPdf(Source(Seq.empty)))
+
+      result shouldBe Right(())
+
+      verify(mockRequestBuilder, times(1))
+        .execute(any(), any())
+
+      reset(mockRequestBuilder)
     }
 
-    "return false if post to DMS queue fails" in {
-      test(INTERNAL_SERVER_ERROR, false)
+    "return UpstreamErrorResponse if post to DMS queue fails" in {
+
+      val upstream5xxResponse = UpstreamErrorResponse.apply("", INTERNAL_SERVER_ERROR)
+
+      when(mockHttpClient.post(any())(any())).thenReturn(mockRequestBuilder)
+      when(mockRequestBuilder.setHeader(any())).thenReturn(mockRequestBuilder)
+      when(mockRequestBuilder.withBody(any())(any(), any(), any())).thenReturn(mockRequestBuilder)
+      when(mockRequestBuilder.execute[Either[UpstreamErrorResponse, HttpResponse]](any(), any()))
+        .thenReturn(Future.successful(Left(upstream5xxResponse)))
+
+      val result = await(connector.sendPdf(Source(Seq.empty)))
+
+      result shouldBe Left(upstream5xxResponse)
+
+      verify(mockRequestBuilder, times(2))
+        .execute(any(), any())
+
+      reset(mockRequestBuilder)
     }
   }
-
-  private def test(status: Int, expected: Boolean) = {
-    implicit val request = FakeRequest("", "")
-
-    when(mockHttpClient.post(any())(any())).thenReturn(mockRequestBuilder)
-    when(mockRequestBuilder.setHeader(any())).thenReturn(mockRequestBuilder)
-    when(mockRequestBuilder.withBody(any())(any(), any(), any())).thenReturn(mockRequestBuilder)
-    when(mockRequestBuilder.execute[HttpResponse](any(), any())).thenReturn(Future.successful(TestResponse(status)))
-
-    val result = await(connector.sendPdf(Source(Seq.empty)))
-
-    result shouldBe expected
-
-    verify(mockRequestBuilder, times(1))
-      .execute(any(), any())
-
-    reset(mockRequestBuilder)
-  }
-}
-
-case class TestResponse(
-  status: Int
-) extends HttpResponse {
-  override def body: String                         = ""
-  override def allHeaders: Map[String, Seq[String]] = Map.empty
 }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/DmsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/DmsConnectorSpec.scala
@@ -44,16 +44,19 @@ class DmsConnectorSpec extends SpecBase {
   )
 
   "sendPdf" should {
-    "return Unit if post to DMS queue succeeds" in {
+    "return HttpResponse if post to DMS queue succeeds" in {
+
+      val expectedResponse = HttpResponse.apply(ACCEPTED, "")
+
       when(mockHttpClient.post(any())(any())).thenReturn(mockRequestBuilder)
       when(mockRequestBuilder.setHeader(any())).thenReturn(mockRequestBuilder)
       when(mockRequestBuilder.withBody(any())(any(), any(), any())).thenReturn(mockRequestBuilder)
       when(mockRequestBuilder.execute[Either[UpstreamErrorResponse, HttpResponse]](any(), any()))
-        .thenReturn(Future.successful(Right(HttpResponse.apply(OK, ""))))
+        .thenReturn(Future.successful(Right(expectedResponse)))
 
       val result = await(connector.sendPdf(Source(Seq.empty)))
 
-      result shouldBe Right(())
+      result shouldBe Right(expectedResponse)
 
       verify(mockRequestBuilder, times(1))
         .execute(any(), any())

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmissionControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmissionControllerSpec.scala
@@ -113,7 +113,7 @@ class RegistrationSubmissionControllerSpec extends SpecBase {
           .thenReturn(Right(registration).validNel)
 
         when(mockDmsService.submitToDms(any(), any())(any()))
-          .thenReturn(Future.successful(subscriptionResponse.success))
+          .thenReturn(Future.successful(Right(subscriptionResponse.success)))
 
         val result: Future[Result] =
           controller.submitRegistration(registration.internalId)(fakeRequest)

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/services/DmsServiceSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/services/DmsServiceSpec.scala
@@ -20,7 +20,7 @@ import org.mockito.ArgumentMatchers.any
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.DmsConnector
 import uk.gov.hmrc.economiccrimelevyregistration.models.integrationframework.CreateEclSubscriptionResponsePayload
-import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.http.{HttpResponse, UpstreamErrorResponse}
 
 import java.time.Instant
 import java.util.Base64
@@ -36,9 +36,10 @@ class DmsServiceSpec extends SpecBase {
 
   "submitToDms" should {
     "return correct value when the submission is successful" in {
-      val encoded = Base64.getEncoder.encodeToString(html.getBytes)
+      val encoded          = Base64.getEncoder.encodeToString(html.getBytes)
+      val expectedResponse = HttpResponse.apply(ACCEPTED, "")
 
-      when(mockDmsConnector.sendPdf(any())(any())).thenReturn(Future.successful(Right(())))
+      when(mockDmsConnector.sendPdf(any())(any())).thenReturn(Future.successful(Right(expectedResponse)))
 
       val result = await(service.submitToDms(Some(encoded), now))
 


### PR DESCRIPTION
- InternalAuthTokenInitialiser now sets up the config in a locally running internal-auth service to allow the dms-submission service to use the callback we have.
- Refactored retry logic on Dms submission to return error or unit. We should not be throwing exceptions to control application flow.