### PR TITLE
Share internal-auth initialiser between resource & returns

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/config/InternalAuthTokenInitialiser.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/config/InternalAuthTokenInitialiser.scala
@@ -139,6 +139,10 @@ class InternalAuthTokenInitialiserImpl @Inject() (
              |    "grantees": [
              |      {
              |        "granteeType": "user",
+             |        "identifier": "economic-crime-levy-returns"
+             |      },
+             |      {
+             |        "granteeType": "user",
              |        "identifier": "economic-crime-levy-registration"
              |      }
              |    ],
@@ -160,6 +164,13 @@ class InternalAuthTokenInitialiserImpl @Inject() (
              |      }
              |    ],
              |    "permissions": [
+             |      {
+             |        "resourceType": "economic-crime-levy-returns",
+             |        "resourceLocation": "dms-returns-callback",
+             |        "actions": [
+             |          "WRITE"
+             |        ]
+             |      },
              |      {
              |        "resourceType": "economic-crime-levy-registration",
              |        "resourceLocation": "dms-registration-callback",
@@ -198,6 +209,12 @@ class InternalAuthTokenInitialiserImpl @Inject() (
              |      "READ",
              |      "WRITE",
              |      "DELETE"
+             |    ]
+             |  },
+             |  {
+             |    "resourceType": "economic-crime-levy-returns",
+             |    "actions": [
+             |      "WRITE"
              |    ]
              |  },
              |  {


### PR DESCRIPTION
Don't want to override grants for returns when setting up registration in internal-auth

Is only for LOCAL testing. Won't effect environment code as it's never ran in environments.