### PR TITLE
ECL-641: Email address not available from session on Registration amendment

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/BaseController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/BaseController.scala
@@ -20,7 +20,7 @@ import cats.data.EitherT
 import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.mvc.Results.{Ok, Status}
-import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationAdditionalInfo
+import uk.gov.hmrc.economiccrimelevyregistration.models.{RegistrationAdditionalInfo, SessionData}
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.ResponseError
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -51,12 +51,17 @@ trait BaseController {
 
   implicit val unitResponse: Converter[Unit] =
     new Converter[Unit] {
-      override def getResponse(response: Unit) = Ok
+      override def getResponse(response: Unit): Status = Ok
     }
 
   implicit val registrationAdditionalInfoResponse: Converter[RegistrationAdditionalInfo] =
     new Converter[RegistrationAdditionalInfo] {
-      override def getResponse(response: RegistrationAdditionalInfo) = Ok(Json.toJson(response))
+      override def getResponse(response: RegistrationAdditionalInfo): Result = Ok(Json.toJson(response))
+    }
+
+  implicit val sessionDataResponse: Converter[SessionData] =
+    new Converter[SessionData] {
+      override def getResponse(response: SessionData): Result = Ok(Json.toJson(response))
     }
 
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/BaseController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/BaseController.scala
@@ -38,30 +38,33 @@ trait BaseController {
 
   implicit class ResponseHandler[R](value: EitherT[Future, ResponseError, R]) {
 
-    def convertToResult(implicit c: Converter[R], ec: ExecutionContext): Future[Result] =
+    def convertToResult(responseCode: Int)(implicit c: Converter[R], ec: ExecutionContext): Future[Result] =
       value.fold(
         err => Status(err.code.statusCode)(Json.toJson(err)),
-        response => c.getResponse(response)
+        response => c.getResponse(response, responseCode)
       )
   }
 
   trait Converter[R] {
-    def getResponse(response: R): Result
+    def getResponse(response: R, responseCode: Int): Result
   }
 
   implicit val unitResponse: Converter[Unit] =
     new Converter[Unit] {
-      override def getResponse(response: Unit): Status = Ok
+      override def getResponse(response: Unit, responseCode: Int): Status = Status(responseCode)
     }
 
   implicit val registrationAdditionalInfoResponse: Converter[RegistrationAdditionalInfo] =
     new Converter[RegistrationAdditionalInfo] {
-      override def getResponse(response: RegistrationAdditionalInfo): Result = Ok(Json.toJson(response))
+      override def getResponse(response: RegistrationAdditionalInfo, responseCode: Int): Result = Status(responseCode)(
+        Json.toJson(response)
+      )
     }
 
   implicit val sessionDataResponse: Converter[SessionData] =
     new Converter[SessionData] {
-      override def getResponse(response: SessionData): Result = Ok(Json.toJson(response))
+      override def getResponse(response: SessionData, responseCode: Int): Result =
+        Status(responseCode)(Json.toJson(response))
     }
 
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationAdditionalInfoController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationAdditionalInfoController.scala
@@ -40,19 +40,19 @@ class RegistrationAdditionalInfoController @Inject() (
     withJsonBody[RegistrationAdditionalInfo] { registrationAdditionalInfo =>
       (for {
         unit <- registrationAdditionalInfoService.upsert(registrationAdditionalInfo).asResponseError
-      } yield unit).convertToResult
+      } yield unit).convertToResult(OK)
     }
   }
 
   def get(id: String): Action[AnyContent] = authorise.async { _ =>
     (for {
       registrationAdditionalInfo <- registrationAdditionalInfoService.get(id).asResponseError
-    } yield registrationAdditionalInfo).convertToResult
+    } yield registrationAdditionalInfo).convertToResult(OK)
   }
 
   def delete(id: String): Action[AnyContent] = authorise.async { _ =>
     (for {
       unit <- registrationAdditionalInfoService.delete(id).asResponseError
-    } yield unit).convertToResult
+    } yield unit).convertToResult(NO_CONTENT)
   }
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/SessionController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/SessionController.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.controllers
+
+import play.api.libs.json.JsValue
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.AuthorisedAction
+import uk.gov.hmrc.economiccrimelevyregistration.models.{RegistrationAdditionalInfo, SessionData}
+import uk.gov.hmrc.economiccrimelevyregistration.services.{RegistrationAdditionalInfoService, SessionService}
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton()
+class SessionController @Inject() (
+  cc: ControllerComponents,
+  sessionService: SessionService,
+  authorise: AuthorisedAction
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc)
+    with BaseController
+    with ErrorHandler {
+
+  def upsert: Action[JsValue] = authorise(parse.json).async { implicit request =>
+    withJsonBody[SessionData] { sessionData =>
+      (for {
+        unit <- sessionService.upsert(sessionData).asResponseError
+      } yield unit).convertToResult
+    }
+  }
+
+  def get(id: String): Action[AnyContent] = authorise.async { _ =>
+    (for {
+      sessionData <- sessionService.get(id).asResponseError
+    } yield sessionData).convertToResult
+  }
+
+  def delete(id: String): Action[AnyContent] = authorise.async { _ =>
+    (for {
+      unit <- sessionService.delete(id).asResponseError
+    } yield unit).convertToResult
+  }
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/SessionController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/SessionController.scala
@@ -19,8 +19,8 @@ package uk.gov.hmrc.economiccrimelevyregistration.controllers
 import play.api.libs.json.JsValue
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.AuthorisedAction
-import uk.gov.hmrc.economiccrimelevyregistration.models.{RegistrationAdditionalInfo, SessionData}
-import uk.gov.hmrc.economiccrimelevyregistration.services.{RegistrationAdditionalInfoService, SessionService}
+import uk.gov.hmrc.economiccrimelevyregistration.models.SessionData
+import uk.gov.hmrc.economiccrimelevyregistration.services.SessionService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.{Inject, Singleton}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/SessionController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/SessionController.scala
@@ -40,19 +40,19 @@ class SessionController @Inject() (
     withJsonBody[SessionData] { sessionData =>
       (for {
         unit <- sessionService.upsert(sessionData).asResponseError
-      } yield unit).convertToResult
+      } yield unit).convertToResult(OK)
     }
   }
 
   def get(id: String): Action[AnyContent] = authorise.async { _ =>
     (for {
       sessionData <- sessionService.get(id).asResponseError
-    } yield sessionData).convertToResult
+    } yield sessionData).convertToResult(OK)
   }
 
   def delete(id: String): Action[AnyContent] = authorise.async { _ =>
     (for {
       unit <- sessionService.delete(id).asResponseError
-    } yield unit).convertToResult
+    } yield unit).convertToResult(NO_CONTENT)
   }
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/RegistrationType.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/RegistrationType.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.models
 
-import play.api.libs.json.{Format, JsError, JsResult, JsString, JsSuccess, JsValue, Json}
+import play.api.libs.json.{Format, JsError, JsResult, JsString, JsSuccess, JsValue}
 import play.api.mvc.JavascriptLiteral
 
 sealed abstract class RegistrationType(value: String)

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/SessionData.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/SessionData.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.models
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.Instant
+
+case class SessionData(internalId: String, lastUpdated: Option[Instant])
+
+object SessionData {
+  implicit val format: OFormat[SessionData] = Json.format[SessionData]
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/SessionData.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/SessionData.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{Json, OFormat}
 
 import java.time.Instant
 
-case class SessionData(internalId: String, lastUpdated: Option[Instant])
+case class SessionData(internalId: String, values: Map[String, String], lastUpdated: Option[Instant])
 
 object SessionData {
   implicit val format: OFormat[SessionData] = Json.format[SessionData]

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/repositories/RegistrationAdditionalInfoRepository.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/repositories/RegistrationAdditionalInfoRepository.scala
@@ -21,7 +21,7 @@ import org.mongodb.scala.model.Indexes.ascending
 import org.mongodb.scala.model._
 import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
-import uk.gov.hmrc.economiccrimelevyregistration.models.{Registration, RegistrationAdditionalInfo}
+import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationAdditionalInfo
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/repositories/SessionRepository.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/repositories/SessionRepository.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.repositories
+
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.Indexes.ascending
+import org.mongodb.scala.model._
+import play.api.libs.json.{Format, Json}
+import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
+import uk.gov.hmrc.economiccrimelevyregistration.models.SessionData
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+
+import java.time.{Clock, Instant}
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SessionRepository @Inject() (
+  mongoComponent: MongoComponent,
+  appConfig: AppConfig,
+  clock: Clock
+)(implicit ec: ExecutionContext)
+    extends PlayMongoRepository[SessionData](
+      collectionName = "session",
+      mongoComponent = mongoComponent,
+      domainFormat = SessionRepository.format,
+      indexes = Seq(
+        IndexModel(
+          Indexes.ascending("lastUpdated"),
+          IndexOptions()
+            .name("lastUpdatedIdx")
+            .expireAfter(appConfig.mongoTtl, TimeUnit.SECONDS)
+        ),
+        IndexModel(ascending("internalId"), IndexOptions().name("internalIdIdx").unique(true))
+      )
+    ) {
+
+  private def byId(id: String): Bson = Filters.equal("internalId", id)
+
+  def keepAlive(id: String): Future[Boolean] =
+    collection
+      .updateOne(
+        filter = byId(id),
+        update = Updates.set("lastUpdated", Instant.now(clock))
+      )
+      .toFuture()
+      .map(_ => true)
+
+  def get(id: String): Future[Option[SessionData]] =
+    keepAlive(id).flatMap { _ =>
+      collection
+        .find(byId(id))
+        .headOption()
+    }
+
+  def upsert(session: SessionData): Future[Unit] = {
+    val updatedSession = session.copy(lastUpdated = Some(Instant.now(clock)))
+
+    collection
+      .replaceOne(
+        filter = byId(updatedSession.internalId),
+        replacement = updatedSession,
+        options = ReplaceOptions().upsert(true)
+      )
+      .toFuture()
+      .map(_ => ())
+  }
+
+  def deleteRecord(id: String): Future[Unit] =
+    collection
+      .deleteOne(byId(id))
+      .toFuture()
+      .map(_ => ())
+}
+
+object SessionRepository {
+  implicit val instantFormat: Format[Instant] = MongoJavatimeFormats.instantFormat
+
+  val format: Format[SessionData] = Json.format[SessionData]
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/RegistrationValidationService.scala
@@ -19,8 +19,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.services
 import cats.data.Validated.Valid
 import cats.data.ValidatedNel
 import cats.implicits._
-import play.api.libs.json.Json
-import uk.gov.hmrc.economiccrimelevyregistration.models.AmlSupervisorType.{FinancialConductAuthority, GamblingCommission, Hmrc, Unknown}
+import uk.gov.hmrc.economiccrimelevyregistration.models.AmlSupervisorType.{FinancialConductAuthority, GamblingCommission, Hmrc}
 import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType._
 import uk.gov.hmrc.economiccrimelevyregistration.models.OtherEntityType.{Charity, NonUKEstablishment, Trust, UnincorporatedAssociation}
 import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationType.Amendment

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/SessionService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/SessionService.scala
@@ -17,9 +17,9 @@
 package uk.gov.hmrc.economiccrimelevyregistration.services
 
 import cats.data.EitherT
-import uk.gov.hmrc.economiccrimelevyregistration.models.{RegistrationAdditionalInfo, SessionData}
+import uk.gov.hmrc.economiccrimelevyregistration.models.SessionData
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataRetrievalError
-import uk.gov.hmrc.economiccrimelevyregistration.repositories.{RegistrationAdditionalInfoRepository, SessionRepository}
+import uk.gov.hmrc.economiccrimelevyregistration.repositories.SessionRepository
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -27,9 +27,9 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class SessionService @Inject() (
   sessionRepository: SessionRepository
-) {
+)(implicit ec: ExecutionContext) {
 
-  def get(id: String)(implicit ec: ExecutionContext): EitherT[Future, DataRetrievalError, SessionData] =
+  def get(id: String): EitherT[Future, DataRetrievalError, SessionData] =
     EitherT {
       sessionRepository.get(id).map {
         case Some(value) => Right(value)
@@ -39,7 +39,7 @@ class SessionService @Inject() (
 
   def upsert(
     sessionData: SessionData
-  )(implicit ec: ExecutionContext): EitherT[Future, DataRetrievalError, Unit] =
+  ): EitherT[Future, DataRetrievalError, Unit] =
     EitherT {
       sessionRepository.upsert(sessionData).map(Right(_)).recover { case e =>
         Left(DataRetrievalError.InternalUnexpectedError(e.getMessage, Some(e)))
@@ -48,7 +48,7 @@ class SessionService @Inject() (
 
   def delete(
     id: String
-  )(implicit ec: ExecutionContext): EitherT[Future, DataRetrievalError, Unit] =
+  ): EitherT[Future, DataRetrievalError, Unit] =
     EitherT {
       sessionRepository.deleteRecord(id).map(Right(_)).recover { case e =>
         Left(DataRetrievalError.InternalUnexpectedError(e.getMessage, Some(e)))

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/SessionService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/SessionService.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.services
+
+import cats.data.EitherT
+import uk.gov.hmrc.economiccrimelevyregistration.models.{RegistrationAdditionalInfo, SessionData}
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataRetrievalError
+import uk.gov.hmrc.economiccrimelevyregistration.repositories.{RegistrationAdditionalInfoRepository, SessionRepository}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SessionService @Inject() (
+  sessionRepository: SessionRepository
+) {
+
+  def get(id: String)(implicit ec: ExecutionContext): EitherT[Future, DataRetrievalError, SessionData] =
+    EitherT {
+      sessionRepository.get(id).map {
+        case Some(value) => Right(value)
+        case None        => Left(DataRetrievalError.NotFound(id))
+      }
+    }
+
+  def upsert(
+    sessionData: SessionData
+  )(implicit ec: ExecutionContext): EitherT[Future, DataRetrievalError, Unit] =
+    EitherT {
+      sessionRepository.upsert(sessionData).map(Right(_)).recover { case e =>
+        Left(DataRetrievalError.InternalUnexpectedError(e.getMessage, Some(e)))
+      }
+    }
+
+  def delete(
+    id: String
+  )(implicit ec: ExecutionContext): EitherT[Future, DataRetrievalError, Unit] =
+    EitherT {
+      sessionRepository.deleteRecord(id).map(Right(_)).recover { case e =>
+        Left(DataRetrievalError.InternalUnexpectedError(e.getMessage, Some(e)))
+      }
+    }
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,6 +8,9 @@ GET           /registration-additional-info/:id              uk.gov.hmrc.economi
 PUT           /registration-additional-info                  uk.gov.hmrc.economiccrimelevyregistration.controllers.RegistrationAdditionalInfoController.upsert
 DELETE        /registration-additional-info/:id              uk.gov.hmrc.economiccrimelevyregistration.controllers.RegistrationAdditionalInfoController.delete(id)
 
+GET           /session/:id                                   uk.gov.hmrc.economiccrimelevyregistration.controllers.SessionController.get(id)
+PUT           /session                                       uk.gov.hmrc.economiccrimelevyregistration.controllers.SessionController.upsert
+DELETE        /session/:id                                   uk.gov.hmrc.economiccrimelevyregistration.controllers.SessionController.delete(id)
 
 GET           /registrations/:id/validation-errors           uk.gov.hmrc.economiccrimelevyregistration.controllers.RegistrationValidationController.getValidationErrors(id)
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationAdditionalInfoISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationAdditionalInfoISpec.scala
@@ -22,8 +22,7 @@ import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.ResponseError
-import uk.gov.hmrc.economiccrimelevyregistration.models.{Registration, RegistrationAdditionalInfo}
-import uk.gov.hmrc.play.bootstrap.backend.http.ErrorResponse
+import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationAdditionalInfo
 
 class RegistrationAdditionalInfoISpec extends ISpecBase {
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationAdditionalInfoISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationAdditionalInfoISpec.scala
@@ -102,7 +102,7 @@ class RegistrationAdditionalInfoISpec extends ISpecBase {
         callRoute(FakeRequest(routes.RegistrationAdditionalInfoController.get(registrationAdditionalInfo.internalId)))
 
       status(getResultBeforeDelete) shouldBe OK
-      status(deleteResult)          shouldBe OK
+      status(deleteResult)          shouldBe NO_CONTENT
       status(getResultAfterDelete)  shouldBe NOT_FOUND
     }
   }

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/SessionISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/SessionISpec.scala
@@ -102,7 +102,7 @@ class SessionISpec extends ISpecBase {
         callRoute(FakeRequest(routes.RegistrationAdditionalInfoController.get(registrationAdditionalInfo.internalId)))
 
       status(getResultBeforeDelete) shouldBe OK
-      status(deleteResult)          shouldBe OK
+      status(deleteResult)          shouldBe NO_CONTENT
       status(getResultAfterDelete)  shouldBe NOT_FOUND
     }
   }

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/SessionISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/SessionISpec.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration
+
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
+import play.api.libs.json.Json
+import play.api.test.FakeRequest
+import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
+import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationAdditionalInfo
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.ResponseError
+
+class SessionISpec extends ISpecBase {
+
+  s"PUT ${routes.SessionController.upsert.url}"                              should {
+    "create or update a registration additional info and return 200 OK with the registration" in {
+      stubAuthorised()
+
+      val registrationAdditionalInfo = random[RegistrationAdditionalInfo]
+
+      lazy val putResult = callRoute(
+        FakeRequest(routes.RegistrationAdditionalInfoController.upsert)
+          .withJsonBody(Json.toJson(registrationAdditionalInfo))
+      )
+
+      lazy val getResult =
+        callRoute(FakeRequest(routes.RegistrationAdditionalInfoController.get(registrationAdditionalInfo.internalId)))
+
+      status(putResult)        shouldBe OK
+      status(getResult)        shouldBe OK
+      contentAsJson(getResult) shouldBe Json.toJson(registrationAdditionalInfo.copy(lastUpdated = Some(now)))
+    }
+  }
+
+  s"GET ${routes.RegistrationAdditionalInfoController.get(":id").url}"       should {
+    "return 200 OK with registration additional info that is already in the database" in {
+      stubAuthorised()
+
+      val registrationAdditionalInfo = random[RegistrationAdditionalInfo]
+
+      callRoute(
+        FakeRequest(routes.RegistrationAdditionalInfoController.upsert).withJsonBody(
+          Json.toJson(registrationAdditionalInfo)
+        )
+      ).futureValue
+
+      lazy val result =
+        callRoute(FakeRequest(routes.RegistrationAdditionalInfoController.get(registrationAdditionalInfo.internalId)))
+
+      status(result)        shouldBe OK
+      contentAsJson(result) shouldBe Json.toJson(registrationAdditionalInfo.copy(lastUpdated = Some(now)))
+    }
+
+    "return 404 NOT_FOUND when trying to get a registration that doesn't exist" in {
+      stubAuthorised()
+
+      val result =
+        callRoute(FakeRequest(routes.RegistrationAdditionalInfoController.get("invalidId")))
+
+      status(result)        shouldBe NOT_FOUND
+      contentAsJson(result) shouldBe Json.toJson(
+        ResponseError.notFoundError("Unable to find record with id: invalidId")
+      )
+    }
+  }
+
+  s"DELETE ${routes.RegistrationAdditionalInfoController.delete(":id").url}" should {
+    "delete a registration and return 200 OK" in {
+      stubAuthorised()
+
+      val registrationAdditionalInfo = random[RegistrationAdditionalInfo]
+
+      callRoute(
+        FakeRequest(routes.RegistrationAdditionalInfoController.upsert).withJsonBody(
+          Json.toJson(registrationAdditionalInfo)
+        )
+      ).futureValue
+
+      lazy val getResultBeforeDelete =
+        callRoute(FakeRequest(routes.RegistrationAdditionalInfoController.get(registrationAdditionalInfo.internalId)))
+
+      lazy val deleteResult =
+        callRoute(
+          FakeRequest(routes.RegistrationAdditionalInfoController.delete(registrationAdditionalInfo.internalId))
+        )
+
+      lazy val getResultAfterDelete =
+        callRoute(FakeRequest(routes.RegistrationAdditionalInfoController.get(registrationAdditionalInfo.internalId)))
+
+      status(getResultBeforeDelete) shouldBe OK
+      status(deleteResult)          shouldBe OK
+      status(getResultAfterDelete)  shouldBe NOT_FOUND
+    }
+  }
+
+}

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/repositories/SessionRepositorySpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/repositories/SessionRepositorySpec.scala
@@ -1,0 +1,114 @@
+package uk.gov.hmrc.economiccrimelevyregistration.repositories
+
+import org.mockito.MockitoSugar
+import org.mongodb.scala.model.Filters
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
+import uk.gov.hmrc.economiccrimelevyregistration.models.SessionData
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+import java.time.temporal.ChronoUnit
+import java.time.{Clock, Instant, ZoneId}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class SessionRepositorySpec
+    extends AnyWordSpec
+    with Matchers
+    with DefaultPlayMongoRepositorySupport[SessionData]
+    with ScalaFutures
+    with IntegrationPatience
+    with OptionValues
+    with MockitoSugar {
+
+  private val now              = Instant.now.truncatedTo(ChronoUnit.MILLIS)
+  private val stubClock: Clock = Clock.fixed(now, ZoneId.systemDefault)
+
+  private val session = SessionData(internalId = "test-id", lastUpdated = Some(Instant.ofEpochSecond(1)))
+
+  private val mockAppConfig = mock[AppConfig]
+
+  when(mockAppConfig.mongoTtl) thenReturn 1
+
+  protected override val repository = new SessionRepository(
+    mongoComponent = mongoComponent,
+    appConfig = mockAppConfig,
+    clock = stubClock
+  )
+
+  "upsert" should {
+    "insert a new session with the last updated time set to `now`" in {
+      val expectedResult = session.copy(lastUpdated = Some(now))
+
+      val setResult     = repository.upsert(session).futureValue
+      val updatedRecord = find(Filters.equal("internalId", session.internalId)).futureValue.headOption.value
+
+      setResult     shouldEqual true
+      updatedRecord shouldEqual expectedResult
+    }
+
+    "update an existing session with the last updated time set to `now`" in {
+      insert(session).futureValue
+
+      val expectedResult = session.copy(lastUpdated = Some(now))
+
+      val setResult     = repository.upsert(session).futureValue
+      val updatedRecord = find(Filters.equal("internalId", session.internalId)).futureValue.headOption.value
+
+      setResult     shouldEqual true
+      updatedRecord shouldEqual expectedResult
+    }
+  }
+
+  "get" should {
+    "update the lastUpdated time and get the record when there is a record for the id" in {
+      insert(session.copy(lastUpdated = Some(now))).futureValue
+
+      val result         = repository.get(session.internalId).futureValue
+      val expectedResult = session.copy(lastUpdated = Some(now))
+
+      result.value shouldEqual expectedResult
+    }
+
+    "return None when there is no record for the id" in {
+      repository.get("id that does not exist").futureValue should not be defined
+    }
+  }
+
+  "deleteRecord" should {
+    "remove a record" in {
+      insert(session).futureValue
+
+      val result = repository.deleteRecord(session.internalId).futureValue
+
+      result                                    shouldEqual true
+      repository.get(session.internalId).futureValue should not be defined
+    }
+
+    "return true when there is no record to remove" in {
+      val result = repository.deleteRecord("id that does not exist").futureValue
+
+      result shouldEqual true
+    }
+  }
+
+  "keepAlive" should {
+    "update lastUpdated to `now` and return true when there is a record for the id" in {
+      insert(session).futureValue
+
+      val result = repository.keepAlive(session.internalId).futureValue
+
+      val expectedSession = session.copy(lastUpdated = Some(now))
+
+      result shouldEqual true
+      val updatedSession = find(Filters.equal("internalId", session.internalId)).futureValue.headOption.value
+      updatedSession shouldEqual expectedSession
+    }
+
+    "return true when there is no record for the id" in {
+      repository.keepAlive("id that does not exist").futureValue shouldEqual true
+    }
+  }
+}

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/repositories/SessionRepositorySpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/repositories/SessionRepositorySpec.scala
@@ -26,7 +26,11 @@ class SessionRepositorySpec
   private val now              = Instant.now.truncatedTo(ChronoUnit.MILLIS)
   private val stubClock: Clock = Clock.fixed(now, ZoneId.systemDefault)
 
-  private val session = SessionData(internalId = "test-id", lastUpdated = Some(Instant.ofEpochSecond(1)))
+  private val session = SessionData(
+    internalId = "test-id",
+    values = Map("email" -> "example@hmrc.com"),
+    lastUpdated = Some(Instant.ofEpochSecond(1))
+  )
 
   private val mockAppConfig = mock[AppConfig]
 
@@ -45,7 +49,7 @@ class SessionRepositorySpec
       val setResult     = repository.upsert(session).futureValue
       val updatedRecord = find(Filters.equal("internalId", session.internalId)).futureValue.headOption.value
 
-      setResult     shouldEqual true
+      setResult     shouldEqual ()
       updatedRecord shouldEqual expectedResult
     }
 
@@ -57,7 +61,7 @@ class SessionRepositorySpec
       val setResult     = repository.upsert(session).futureValue
       val updatedRecord = find(Filters.equal("internalId", session.internalId)).futureValue.headOption.value
 
-      setResult     shouldEqual true
+      setResult     shouldEqual ()
       updatedRecord shouldEqual expectedResult
     }
   }
@@ -83,14 +87,14 @@ class SessionRepositorySpec
 
       val result = repository.deleteRecord(session.internalId).futureValue
 
-      result                                    shouldEqual true
+      result                                    shouldEqual ()
       repository.get(session.internalId).futureValue should not be defined
     }
 
     "return true when there is no record to remove" in {
       val result = repository.deleteRecord("id that does not exist").futureValue
 
-      result shouldEqual true
+      result shouldEqual ()
     }
   }
 

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
@@ -60,5 +60,6 @@ object CachedArbitraries extends EclTestData {
   implicit lazy val arbEntitySubType: Arbitrary[OtherEntityType]                                         = mkArb
   implicit lazy val arbUtrType: Arbitrary[UtrType]                                                       = mkArb
   implicit lazy val arbDmsNotification: Arbitrary[DmsNotification]                                       = mkArb
+  implicit lazy val arbSessionData: Arbitrary[SessionData]                                               = mkArb
 
 }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationAdditionalInfoControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationAdditionalInfoControllerSpec.scala
@@ -121,7 +121,7 @@ class RegistrationAdditionalInfoControllerSpec extends SpecBase {
   }
 
   "delete" should {
-    "return 200 OK when deleting a registration additional info record succeeds" in forAll {
+    "return 204 NO_CONTENT when deleting a registration additional info record succeeds" in forAll {
       registrationAdditionalInfo: RegistrationAdditionalInfo =>
         when(
           mockRegistrationAdditionalInfoService.delete(ArgumentMatchers.eq(registrationAdditionalInfo.internalId))(
@@ -133,7 +133,7 @@ class RegistrationAdditionalInfoControllerSpec extends SpecBase {
         val result: Future[Result] =
           controller.delete(registrationAdditionalInfo.internalId)(fakeRequest)
 
-        status(result) shouldBe OK
+        status(result) shouldBe NO_CONTENT
     }
 
     "return 500 INTERNAL_SERVER_ERROR when deleting a registration additional info fails" in forAll {

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/SessionControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/SessionControllerSpec.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevySessionData.controllers
+
+import cats.data.EitherT
+import org.mockito.ArgumentMatchers.any
+import play.api.libs.json.Json
+import play.api.mvc.Result
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
+import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.SessionController
+import uk.gov.hmrc.economiccrimelevyregistration.models.SessionData
+import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataRetrievalError
+import uk.gov.hmrc.economiccrimelevyregistration.services.SessionService
+import uk.gov.hmrc.play.bootstrap.backend.http.ErrorResponse
+
+import scala.concurrent.Future
+
+class SessionControllerSpec extends SpecBase {
+
+  val mockSessionService: SessionService = mock[SessionService]
+
+  val controller = new SessionController(
+    cc,
+    mockSessionService,
+    fakeAuthorisedAction
+  )
+
+  "upsertSession" should {
+    "return 200 OK with the session that was upserted" in forAll { sessionData: SessionData =>
+      when(mockSessionService.upsert(any())).thenReturn(EitherT.rightT[Future, DataRetrievalError](()))
+
+      val result: Future[Result] =
+        controller.upsert()(
+          fakeRequestWithJsonBody(Json.toJson(sessionData))
+        )
+
+      status(result)        shouldBe OK
+      contentAsJson(result) shouldBe Json.toJson(sessionData)
+    }
+
+    "return 404 NOT_FOUND when there is no SessionData for the id" in forAll { sessionData: SessionData =>
+      when(mockSessionService.upsert(any())).thenReturn(EitherT.leftT[Future, Unit](DataRetrievalError.NotFound("id")))
+
+      val result: Future[Result] =
+        controller.upsert()(
+          fakeRequestWithJsonBody(Json.toJson(sessionData))
+        )
+
+      status(result)        shouldBe NOT_FOUND
+      contentAsJson(result) shouldBe Json.toJson(ErrorResponse(NOT_FOUND, "SessionData not found"))
+    }
+
+    "return 500 INTERNAL_SERVER_ERROR when SessionData retrieval fails" in forAll { sessionData: SessionData =>
+      when(mockSessionService.upsert(any()))
+        .thenReturn(EitherT.leftT[Future, Unit](DataRetrievalError.InternalUnexpectedError("error", None)))
+
+      val result: Future[Result] =
+        controller.upsert()(
+          fakeRequestWithJsonBody(Json.toJson(sessionData))
+        )
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+    }
+  }
+
+  "getSessionData" should {
+    "return 200 OK with an existing SessionData when there is one for the id" in forAll { sessionData: SessionData =>
+      when(mockSessionService.get(any())).thenReturn(EitherT.rightT[Future, DataRetrievalError](Some(SessionData)))
+
+      val result: Future[Result] =
+        controller.get(sessionData.internalId)(fakeRequest)
+
+      status(result)        shouldBe OK
+      contentAsJson(result) shouldBe Json.toJson(sessionData)
+    }
+
+    "return 404 NOT_FOUND when there is no SessionData for the id" in {
+      when(mockSessionService.get(any())).thenReturn(EitherT.rightT[Future, DataRetrievalError](None))
+
+      val result: Future[Result] =
+        controller.get("id")(fakeRequest)
+
+      status(result)        shouldBe NOT_FOUND
+      contentAsJson(result) shouldBe Json.toJson(ErrorResponse(NOT_FOUND, "SessionData not found"))
+    }
+
+    "return 500 INTERNAL_SERVER_ERROR when SessionData retrieval fails" in {
+      when(mockSessionService.get(any()))
+        .thenReturn(EitherT.leftT[Future, SessionData](DataRetrievalError.InternalUnexpectedError("error", None)))
+
+      val result: Future[Result] =
+        controller.get("id")(fakeRequest)
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+    }
+  }
+
+  "deleteSessionData" should {
+    "return 204 NO_CONTENT when deletion of SessionData with the given id is successful" in {
+      when(mockSessionService.delete(any())).thenReturn(EitherT.rightT[Future, DataRetrievalError](()))
+
+      val result: Future[Result] =
+        controller.delete("id")(fakeRequest)
+
+      status(result) shouldBe NO_CONTENT
+    }
+
+    "return 404 NOT_FOUND when there is no SessionData for the id" in {
+      when(mockSessionService.delete(any())).thenReturn(EitherT.leftT[Future, Unit](DataRetrievalError.NotFound("id")))
+
+      val result: Future[Result] =
+        controller.delete("id")(fakeRequest)
+
+      status(result)        shouldBe NOT_FOUND
+      contentAsJson(result) shouldBe Json.toJson(ErrorResponse(NOT_FOUND, "SessionData not found"))
+    }
+
+    "return 500 INTERNAL_SERVER_ERROR when SessionData deletion fails" in {
+      when(mockSessionService.delete(any()))
+        .thenReturn(EitherT.leftT[Future, Unit](DataRetrievalError.InternalUnexpectedError("error", None)))
+
+      val result: Future[Result] =
+        controller.delete("id")(fakeRequest)
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+    }
+  }
+
+}


### PR DESCRIPTION
Adding new endpoints to store session values. This will prevent us from failing when a user's session is cleared during the journey and also to save the information entered by a user for an unfinished journey.